### PR TITLE
Feature/webcomponents support

### DIFF
--- a/app/html/panel/ui5/index.html
+++ b/app/html/panel/ui5/index.html
@@ -171,7 +171,7 @@
         <!-- No UI5 dialog /start-->
         <overlay id="supportability" hidden="true">
             <section no-ui5-version>
-                <h1>There is no OpenUI5/SAPUI5 found on this page</h1>
+                <h1>There is no OpenUI5/SAPUI5 or UI5 Web Components found on this page</h1>
 
                 <p>
                     What is OpenUI5?<br/>
@@ -187,6 +187,7 @@
 
                 <p>
                     Read more at <a href="http://openui5.org/" target="_openui5">http://openui5.org/</a>
+                    or <a href="https://sap.github.io/ui5-webcomponents/" target="_webcomponents">UI5 Web Components</a>
                 </p>
             </section>
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -15,6 +15,16 @@
                 "http://*/*",
                 "https://*/*"
             ]
+        },
+        {
+            "js": [
+                "/scripts/content/detectWebComponents.js"
+            ],
+            "all_frames": true,
+            "matches": [
+                "http://*/*",
+                "https://*/*"
+            ]
         }
     ],
     "content_security_policy": {
@@ -52,6 +62,7 @@
             "resources": [
                 "/scripts/injected/*.js",
                 "/vendor/ToolsAPI.js",
+                "/vendor/WebComponentsToolsAPI.js",
                 "/vendor/ace.js",
                 "/vendor/ext-searchbox.js",
                 "/vendor/mode-json.js",

--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -90,11 +90,21 @@
                     if (frameId !== undefined) {
                         target.frameIds = [message.frameId];
                     }
+                    // 1. Inject the isolated-world message bridge (mirrors
+                    //    content/main.js for classic UI5).
                     chrome.scripting.executeScript({
                         target,
-                        files: ['/vendor/WebComponentsToolsAPI.js'],
-                        world: 'MAIN'
+                        files: ['/scripts/content/webcMain.js']
                     }).then(() => {
+                        // 2. Inject the tools API into the page's MAIN world so
+                        //    it can see the framework classes / isUI5Element.
+                        return chrome.scripting.executeScript({
+                            target,
+                            files: ['/vendor/WebComponentsToolsAPI.js'],
+                            world: 'MAIN'
+                        });
+                    }).then(() => {
+                        // 3. Inject the MAIN-world handler script.
                         return chrome.scripting.executeScript({
                             target,
                             files: ['/scripts/injected/webcMain.js'],

--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -6,7 +6,7 @@
     var pageAction = require('../modules/background/pageAction.js');
 
     var contextMenu = new ContextMenu({
-        title: 'Inspect UI5 control',
+        title: 'Inspect UI5 element',
         id: 'context-menu',
         contexts: ['all']
     });

--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -80,6 +80,36 @@
             });
         },
 
+        'do-webc-injection': function (message) {
+            const frameId = message.frameId;
+            chrome.windows.getCurrent().then(w => {
+                chrome.tabs.query({ active: true, windowId: w.id }).then(tabs => {
+                    const target = {
+                        tabId: tabs[0].id
+                    };
+                    if (frameId !== undefined) {
+                        target.frameIds = [message.frameId];
+                    }
+                    chrome.scripting.executeScript({
+                        target,
+                        files: ['/vendor/WebComponentsToolsAPI.js'],
+                        world: 'MAIN'
+                    }).then(() => {
+                        return chrome.scripting.executeScript({
+                            target,
+                            files: ['/scripts/injected/webcMain.js'],
+                            world: 'MAIN'
+                        });
+                    }).then(() => {
+                        chrome.runtime.sendMessage({
+                            action: 'on-webc-script-injection',
+                            frameId: frameId
+                        });
+                    });
+                });
+            });
+        },
+
         /**
          * Set the element that was clicked with the right button of the mouse.
          * @param {Object} message

--- a/app/scripts/content/detectWebComponents.js
+++ b/app/scripts/content/detectWebComponents.js
@@ -1,0 +1,37 @@
+(function () {
+    'use strict';
+    var utils = require('../modules/utils/utils.js');
+    var port = utils.getPort();
+
+    var script = document.createElement('script');
+    script.src = chrome.runtime.getURL('/scripts/injected/detectWebComponents.js');
+    document.head.appendChild(script);
+
+    script.onload = function () {
+        script.parentNode.removeChild(script);
+    };
+
+    // Bridge messages from background/panel to the injected webcMain.js script
+    port.onMessage(function (message) {
+        if (message.action === 'do-webc-detection') {
+            document.dispatchEvent(new CustomEvent('do-webc-detection-injected'));
+            return;
+        }
+
+        // Forward all actions to injected script via CustomEvent
+        // (webcMain.js ignores actions it doesn't handle)
+        document.dispatchEvent(new CustomEvent('ui5-communication-with-injected-script', {
+            detail: message
+        }));
+    });
+
+    // Bridge messages from injected webcMain.js back to background
+    document.addEventListener('ui5-communication-with-content-script', function (event) {
+        port.postMessage(event.detail);
+    }, false);
+
+    // Keep the detection bridge
+    document.addEventListener('detect-webc-content', function (event) {
+        port.postMessage(event.detail);
+    }, false);
+}());

--- a/app/scripts/content/detectWebComponents.js
+++ b/app/scripts/content/detectWebComponents.js
@@ -11,26 +11,15 @@
         script.parentNode.removeChild(script);
     };
 
-    // Bridge messages from background/panel to the injected webcMain.js script
+    // Listen for detection requests from the panel and forward to the
+    // injected detector.
     port.onMessage(function (message) {
         if (message.action === 'do-webc-detection') {
             document.dispatchEvent(new CustomEvent('do-webc-detection-injected'));
-            return;
         }
-
-        // Forward all actions to injected script via CustomEvent
-        // (webcMain.js ignores actions it doesn't handle)
-        document.dispatchEvent(new CustomEvent('ui5-communication-with-injected-script', {
-            detail: message
-        }));
     });
 
-    // Bridge messages from injected webcMain.js back to background
-    document.addEventListener('ui5-communication-with-content-script', function (event) {
-        port.postMessage(event.detail);
-    }, false);
-
-    // Keep the detection bridge
+    // Forward the detection result from the injected detector to the background.
     document.addEventListener('detect-webc-content', function (event) {
         port.postMessage(event.detail);
     }, false);

--- a/app/scripts/content/main.js
+++ b/app/scripts/content/main.js
@@ -1,7 +1,8 @@
 (function () {
     'use strict';
     var utils = require('../modules/utils/utils.js');
-    var highLighter = require('../modules/content/highLighter.js');
+    var highLighterModule = require('../modules/content/highLighter.js');
+    var highLighter = highLighterModule.create();
     var port = utils.getPort();
 
     function confirmScriptInjectionDone() {
@@ -75,7 +76,7 @@
          * @param {Object} message
          */
         'on-control-tree-hover': function (message) {
-            highLighter.setDimensions(message.target);
+            highLighter.setDimensions(document.getElementById(message.target));
         },
 
         'on-hide-highlight': function () {

--- a/app/scripts/content/webcMain.js
+++ b/app/scripts/content/webcMain.js
@@ -1,0 +1,27 @@
+(function () {
+    'use strict';
+    var utils = require('../modules/utils/utils.js');
+    var port = utils.getPort();
+
+    // Guard against double injection (e.g. when DevTools are undocked and
+    // re-docked). Without it, a second injection would register duplicate
+    // port/CustomEvent listeners and every message would be handled twice.
+    // Mirrors the DONE_FLAG pattern in content/main.js.
+    var DONE_FLAG = 'WEBC_MAIN_SCRIPT_INJECTION_DONE';
+    if (window[DONE_FLAG] === true) {
+        return;
+    }
+    window[DONE_FLAG] = true;
+
+    // Forward messages from the background/panel to the MAIN-world script.
+    port.onMessage(function (message) {
+        document.dispatchEvent(new CustomEvent('ui5-communication-with-injected-script', {
+            detail: message
+        }));
+    });
+
+    // Forward messages from the MAIN-world script back to the background.
+    document.addEventListener('ui5-communication-with-content-script', function (event) {
+        port.postMessage(event.detail);
+    }, false);
+}());

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -2,6 +2,8 @@
 (function () {
     'use strict';
 
+
+
     // ================================================================================
     // Main controller for 'UI5' tab in devtools
     // ================================================================================
@@ -24,6 +26,7 @@
     var ControllerDetailView = require('../../../modules/ui/ControllerDetailView.js');
     var OElementsRegistryMasterView = require('../../../modules/ui/OElementsRegistryMasterView.js');
     var AIChat = require('../../../modules/ui/AIChat.js');
+
 
     // Apply theme
     // ================================================================================
@@ -385,6 +388,33 @@
         }
     }, sharedDataViewOptions));
 
+    function _getMergedControlTree(frameId) {
+        var fd = frameData[frameId];
+        if (!fd) {
+            return {};
+        }
+        var ui5Tree = fd.controlTreeUI5;
+        var webcTree = fd.controlTreeWebC;
+
+        if (ui5Tree && webcTree) {
+            return {
+                versionInfo: ui5Tree.versionInfo,
+                controls: ui5Tree.controls.concat([{
+                    id: '__webc_root__',
+                    name: '[' + webcTree.versionInfo.framework + ' v' + webcTree.versionInfo.version + ']',
+                    type: 'ui5-web-component',
+                    content: webcTree.controls
+                }])
+            };
+        }
+
+        if (webcTree) {
+            return webcTree;
+        }
+
+        return ui5Tree || {};
+    }
+
     displayFrameData = function (options) {
         var frameId = options.selectedId;
         var oldFrameId = options.oldSelectedId;
@@ -394,7 +424,7 @@
         updateSupportabilityOverlay();
 
         if (UI5Data) {
-            controlTree.setData(UI5Data.controlTree);
+            controlTree.setData(_getMergedControlTree(frameId));
             UI5Data.selectedElementId && controlTree.setSelectedElement(UI5Data.selectedElementId);
             appInfo.setData(UI5Data.applicationInformation);
             UI5Data.elementRegistry && oElementsRegistryMasterView.setData(UI5Data.elementRegistry);
@@ -435,13 +465,21 @@
         var overlayNoUI5Section = overlay.querySelector('[no-ui5-version]');
         var overlayUnsupportedVersionSection = overlay.querySelector('[unsupported-version]');
 
-        var showOverlay = !currentFrameData.isUI5Detected || !currentFrameData.isVersionSupported;
-        var showNoUI5Overlay = !currentFrameData.isUI5Detected;
-        var showUnsupportedVersionOverlay = currentFrameData.isUI5Detected && !currentFrameData.isVersionSupported;
+        var hasAnyFramework = currentFrameData.isUI5Detected || currentFrameData.isWebCDetected;
+        var showOverlay = !hasAnyFramework || (!currentFrameData.isVersionSupported && !currentFrameData.isWebCDetected);
+        var showNoUI5Overlay = !hasAnyFramework;
+        var showUnsupportedVersionOverlay = hasAnyFramework && !currentFrameData.isVersionSupported && !currentFrameData.isWebCDetected;
 
         overlay.hidden = !showOverlay;
         overlayNoUI5Section.style.display = showNoUI5Overlay ? 'block' : 'none';
         overlayUnsupportedVersionSection.style.display = showUnsupportedVersionOverlay ? 'block' : 'none';
+
+        // Pure WebC (no classic UI5): rename "Aggregations" tab to "Slots"
+        var aggregationsTab = document.getElementById('tab-aggregations');
+        if (aggregationsTab) {
+            var isPureWebC = currentFrameData.isWebCDetected && !currentFrameData.isUI5Detected;
+            aggregationsTab.textContent = isPureWebC ? 'Slots' : 'Aggregations';
+        }
     };
 
     framesSelect = new FrameSelect('frame-select', {
@@ -543,11 +581,12 @@
         'on-receiving-initial-data': function (message, messageSender) {
             var frameId = messageSender.frameId;
             frameData[frameId].controlTree = message.controlTree;
+            frameData[frameId].controlTreeUI5 = message.controlTree;
             frameData[frameId].applicationInformation = message.applicationInformation;
             frameData[frameId].elementRegistry = message.elementRegistry;
 
             if (framesSelect.getSelectedId() === frameId) {
-                controlTree.setData(message.controlTree);
+                controlTree.setData(_getMergedControlTree(frameId));
 
                 // Set URL for AI Chat history
                 aiChat.setUrl(frameData[frameId].url);
@@ -576,8 +615,9 @@
             var frameId = messageSender.frameId;
             var frameIds = Object.keys(frameData).map( x => parseInt(x));
             frameData[frameId].controlTree = message.controlTree;
+            frameData[frameId].controlTreeUI5 = message.controlTree;
             if (framesSelect.getSelectedId() === frameId) {
-                controlTree.setData(message.controlTree);
+                controlTree.setData(_getMergedControlTree(frameId));
             }
 
             if (frameIds.length > 1) {
@@ -716,6 +756,60 @@
             }
         },
 
+        'on-webc-detected': function (message, messageSender) {
+            var frameId = messageSender.frameId;
+            if (!frameData[frameId]) {
+                frameData[frameId] = { url: messageSender.url };
+            }
+            frameData[frameId].isWebCDetected = true;
+            framesSelect.setData(frameData);
+
+            if (framesSelect.getSelectedId() === frameId) {
+                updateSupportabilityOverlay();
+            }
+
+            port.postMessage({
+                action: 'do-webc-injection',
+                tabId: chrome.devtools.inspectedWindow.tabId,
+                frameId: frameId
+            });
+        },
+
+        'on-webc-not-detected': function () {
+        },
+
+        'on-webc-script-injection': function (message, messageSender) {
+            var frameId = message.frameId || (messageSender && messageSender.frameId);
+            port.postMessage({
+                action: 'get-initial-information-webc',
+                frameId: frameId
+            });
+        },
+
+        'on-receiving-initial-data-webc': function (message, messageSender) {
+            var frameId = messageSender.frameId;
+            if (!frameData[frameId]) {
+                frameData[frameId] = {};
+            }
+            frameData[frameId].controlTreeWebC = message.controlTree;
+
+            if (framesSelect.getSelectedId() === frameId) {
+                controlTree.setData(_getMergedControlTree(frameId));
+            }
+        },
+
+        'on-application-dom-update-webc': function (message, messageSender) {
+            var frameId = messageSender.frameId;
+            if (!frameData[frameId]) {
+                frameData[frameId] = {};
+            }
+            frameData[frameId].controlTreeWebC = message.controlTree;
+
+            if (framesSelect.getSelectedId() === frameId) {
+                controlTree.setData(_getMergedControlTree(frameId));
+            }
+        },
+
         'on-ping-frames': function(message) {
             var aLatestFrameIds = message.frameIds;
             var aFrameIds = Object.keys(frameData).map(x => parseInt(x));
@@ -758,6 +852,7 @@
     });
 
     port.postMessage({ action: 'do-ui5-detection' });
+    port.postMessage({ action: 'do-webc-detection' });
 
     // Restart everything when the URL is changed
     chrome.devtools.network.onNavigated.addListener(function () {
@@ -765,5 +860,6 @@
         framesSelect.setSelectedId(0);
         framesSelect.setData(frameData);
         port.postMessage({ action: 'do-ui5-detection' });
+        port.postMessage({ action: 'do-webc-detection' });
     });
 }());

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -792,9 +792,16 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
+            // Only set application info if classic UI5 hasn't already provided richer info
+            if (!frameData[frameId].applicationInformation) {
+                frameData[frameId].applicationInformation = message.applicationInformation;
+            }
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
+                if (!frameData[frameId].isUI5Detected) {
+                    appInfo.setData(frameData[frameId].applicationInformation);
+                }
             }
         },
 

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -2,8 +2,6 @@
 (function () {
     'use strict';
 
-
-
     // ================================================================================
     // Main controller for 'UI5' tab in devtools
     // ================================================================================
@@ -55,6 +53,10 @@
     var framesSelect;
     var displayFrameData;
     var updateSupportabilityOverlay;
+    // Synthetic root inserted under the merged tree (mixed pages) to group all
+    // WebC controls under one expandable header. Its id ('__webc_root__') is
+    // reserved: selecting or hovering it in the tree must be a no-op since it
+    // has no corresponding element on the page.
     var sharedDataViewOptions = {
 
         /**
@@ -86,6 +88,10 @@
          * @param {string} selectedElementId
          */
         onSelectionChanged: function (selectedElementId) {
+            // The synthetic WebC group root has no real element; skip.
+            if (selectedElementId === '__webc_root__') {
+                return;
+            }
             port.postMessage({
                 action: 'do-control-select',
                 target: selectedElementId,
@@ -99,6 +105,10 @@
          * @param {string} hoveredElementId
          */
         onHoverChanged: function (hoveredElementId) {
+            // The synthetic WebC group root has no real element; skip.
+            if (hoveredElementId === '__webc_root__') {
+                return;
+            }
             port.postMessage({
                 action: 'on-control-tree-hover',
                 target: hoveredElementId,
@@ -792,13 +802,19 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
-            // Only set application info if classic UI5 hasn't already provided richer info
+            // Precedence rule for the App Info tab on mixed pages: classic UI5
+            // wins because it provides richer info (loaded libraries, modules,
+            // bootstrap config, URL parameters), whereas WebC only emits a
+            // minimal "General" section. We populate from WebC only when
+            // classic hasn't already filled this in.
             if (!frameData[frameId].applicationInformation) {
                 frameData[frameId].applicationInformation = message.applicationInformation;
             }
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
+                // Avoid overwriting the App Info tab if classic UI5 will
+                // populate it shortly (or already did) — same precedence rule.
                 if (!frameData[frameId].isUI5Detected) {
                     appInfo.setData(frameData[frameId].applicationInformation);
                 }

--- a/app/scripts/injected/detectWebComponents.js
+++ b/app/scripts/injected/detectWebComponents.js
@@ -6,6 +6,11 @@
             return '';
         }
         try {
+            // Web components stores runtime info as a JS property `Runtimes` on the meta element
+            if (meta.Runtimes && meta.Runtimes.length > 0 && meta.Runtimes[0].version) {
+                return meta.Runtimes[0].version;
+            }
+            // Fallback: older versions may have used a data attribute
             var runtimesData = meta.getAttribute('data-ui5-shared-resources-runtimes');
             if (!runtimesData) {
                 return '';
@@ -24,10 +29,11 @@
         if (meta) {
             return true;
         }
+        // Definitive check: UI5Element instances expose `isUI5Element === true`.
+        // See packages/base/src/UI5Element.ts (get isUI5Element).
         var allElements = document.querySelectorAll('*');
         for (var i = 0; i < allElements.length; i++) {
-            var localName = allElements[i].localName;
-            if (localName.indexOf('ui5-') === 0 && window.customElements.get(localName)) {
+            if (allElements[i].isUI5Element === true) {
                 return true;
             }
         }

--- a/app/scripts/injected/detectWebComponents.js
+++ b/app/scripts/injected/detectWebComponents.js
@@ -1,0 +1,63 @@
+(function () {
+    'use strict';
+
+    function _extractVersion(meta) {
+        if (!meta) {
+            return '';
+        }
+        try {
+            var runtimesData = meta.getAttribute('data-ui5-shared-resources-runtimes');
+            if (!runtimesData) {
+                return '';
+            }
+            var runtimes = JSON.parse(runtimesData);
+            if (runtimes.length > 0 && runtimes[0].version) {
+                return runtimes[0].version;
+            }
+        } catch (e) {
+            // version extraction is best-effort
+        }
+        return '';
+    }
+
+    function _hasUI5WebComponents(meta) {
+        if (meta) {
+            return true;
+        }
+        var allElements = document.querySelectorAll('*');
+        for (var i = 0; i < allElements.length; i++) {
+            var localName = allElements[i].localName;
+            if (localName.indexOf('ui5-') === 0 && window.customElements.get(localName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function createResponseToContentScript() {
+        var responseToContentScript = Object.create(null);
+        responseToContentScript.detail = Object.create(null);
+        var body = responseToContentScript.detail;
+
+        var meta = document.querySelector('meta[name="ui5-shared-resources"]');
+        var hasWebComponents = _hasUI5WebComponents(meta);
+
+        if (hasWebComponents) {
+            body.action = 'on-webc-detected';
+            body.framework = Object.create(null);
+            body.framework.name = 'UI5 Web Components';
+            body.framework.version = _extractVersion(meta);
+            body.isVersionSupported = true;
+        } else {
+            body.action = 'on-webc-not-detected';
+        }
+
+        return responseToContentScript;
+    }
+
+    document.dispatchEvent(new CustomEvent('detect-webc-content', createResponseToContentScript()));
+
+    document.addEventListener('do-webc-detection-injected', function () {
+        document.dispatchEvent(new CustomEvent('detect-webc-content', createResponseToContentScript()));
+    }, false);
+}());

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -69,7 +69,8 @@
         for (var key in props) {
             formattedProps[key] = Object.create(null);
             formattedProps[key].value = props[key].value;
-            formattedProps[key].isDefault = props[key].isDefault;
+            // No `isDefault`: see the note in WebComponentsToolsAPI.js.
+            // DataView omits the "(default)" badge when this is absent.
             types[key] = props[key].type || 'string';
         }
 

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -196,6 +196,21 @@
 
     mutation.init();
 
+    // Build the actions list for the DataView panel. Web components don't have
+    // an `invalidate()` method (re-rendering is automatic), so we omit it.
+    function _buildControlActions(controlId) {
+        return {
+            actions: {
+                data: ['Focus', 'Copy to Console', 'Copy HTML to Console']
+            },
+            own: {
+                options: {
+                    controlId: controlId
+                }
+            }
+        };
+    }
+
     function _sendControlSelectResponse(controlId) {
         var controlProperties = WebCToolsAPI.getControlProperties(controlId);
         var controlAggregations = WebCToolsAPI.getControlAggregations(controlId);
@@ -207,7 +222,7 @@
             controlBindings: {},
             controlAggregations: _formatAggregations(controlId, controlAggregations),
             controlEvents: _formatEvents(controlId, controlEvents),
-            controlActions: { actions: ['Focus'] }
+            controlActions: _buildControlActions(controlId)
         });
     }
 
@@ -249,6 +264,29 @@
             }
 
             _sendControlSelectResponse(controlId);
+        },
+
+        'do-control-focus': function (event) {
+            var element = WebCToolsAPI.getElementById(event.detail.data.controlId);
+            if (element && typeof element.focus === 'function') {
+                element.focus();
+            }
+        },
+
+        'do-copy-control-to-console': function (event) {
+            var element = WebCToolsAPI.getElementById(event.detail.data.controlId);
+            if (element) {
+                // eslint-disable-next-line no-console
+                console.log(element);
+            }
+        },
+
+        'do-control-copy-html': function (event) {
+            var element = WebCToolsAPI.getElementById(event.detail.target);
+            if (element) {
+                // eslint-disable-next-line no-console
+                console.log(element.outerHTML);
+            }
         }
     };
 

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -222,27 +222,27 @@
         return _section('Configuration', data);
     }
 
-    // Flatten an array into a 1-based-indexed map for DataView display.
-    function _listAsIndexedMap(arr) {
-        var data = {};
-        for (var i = 0; i < arr.length; i++) {
-            data[i + 1] = arr[i];
-        }
-        return data;
+    // DataView preserves array order (and sorts object keys alphabetically).
+    // For long lists we want a stable, readable order — sort the values
+    // alphabetically and emit as an array.
+    function _asSortedArray(arr) {
+        return arr.slice().sort(function (a, b) {
+            return String(a).toLowerCase().localeCompare(String(b).toLowerCase());
+        });
     }
 
     function _registeredTagsSection(tags) {
         if (!Array.isArray(tags) || !tags.length) {
             return null;
         }
-        return _section('Registered tags (' + tags.length + ')', _listAsIndexedMap(tags), false);
+        return _section('Registered tags (' + tags.length + ')', _asSortedArray(tags), false);
     }
 
     function _registeredFeaturesSection(features) {
         if (!Array.isArray(features) || !features.length) {
             return null;
         }
-        return _section('Registered features (' + features.length + ')', _listAsIndexedMap(features), false);
+        return _section('Registered features (' + features.length + ')', _asSortedArray(features), false);
     }
 
     function _interopSection(primary) {
@@ -261,11 +261,11 @@
         if (runtimes.length <= 1) {
             return null;
         }
-        var data = {};
+        var data = [];
         for (var r = 0; r < runtimes.length; r++) {
             var rt = runtimes[r];
-            data[r + 1] = (rt.alias ? rt.alias + ' — ' : '') +
-                (rt.description || ('version ' + (rt.version || 'unknown')));
+            data.push((rt.alias ? rt.alias + ' — ' : '') +
+                (rt.description || ('version ' + (rt.version || 'unknown'))));
         }
         return _section('Runtimes (' + runtimes.length + ')', data);
     }

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -158,24 +158,146 @@
         return result;
     }
 
-    // Build application info in the same shape as classic UI5's applicationUtils.getApplicationInfo()
-    function _buildApplicationInfo(frameworkInformation) {
-        var common = frameworkInformation.commonInformation;
+    // Build a single DataView section: {options, data}. Used by the App Info
+    // tab, which expects this shape per section (see classic UI5's
+    // applicationUtils.getApplicationInfo()).
+    function _section(title, data, expanded) {
+        return {
+            options: {
+                title: title,
+                expandable: true,
+                expanded: expanded !== false
+            },
+            data: data
+        };
+    }
+
+    // Stringify a configuration value for display in the App Info tab.
+    function _formatConfigValue(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        if (typeof value === 'object') {
+            try {
+                return JSON.stringify(value);
+            } catch (e) {
+                return String(value);
+            }
+        }
+        return value;
+    }
+
+    // Build application info in the same shape as classic UI5's
+    // applicationUtils.getApplicationInfo(). Surfaces what the framework
+    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
+    // configuration (theme, language, timezone, ...), registered tags and
+    // features, and a list of runtimes when more than one is active on the
+    // page.
+    // --- App Info section builders. Each returns a {options, data} section
+    // or null if there's nothing to report. ---
+
+    function _generalSection(common) {
         var general = {};
         general[common.frameworkName] = common.version || '(unknown)';
+        if (common.description) {
+            general.Description = common.description;
+        }
         general['User Agent'] = navigator.userAgent;
         general.Application = location.href;
+        return _section('General', general);
+    }
 
-        return {
-            common: {
-                options: {
-                    title: 'General',
-                    expandable: true,
-                    expanded: true
-                },
-                data: general
-            }
+    function _configurationSection(configuration) {
+        if (!configuration) {
+            return null;
+        }
+        var keys = Object.keys(configuration);
+        if (!keys.length) {
+            return null;
+        }
+        var data = {};
+        for (var i = 0; i < keys.length; i++) {
+            data[keys[i]] = _formatConfigValue(configuration[keys[i]]);
+        }
+        return _section('Configuration', data);
+    }
+
+    // Flatten an array into a 1-based-indexed map for DataView display.
+    function _listAsIndexedMap(arr) {
+        var data = {};
+        for (var i = 0; i < arr.length; i++) {
+            data[i + 1] = arr[i];
+        }
+        return data;
+    }
+
+    function _registeredTagsSection(tags) {
+        if (!Array.isArray(tags) || !tags.length) {
+            return null;
+        }
+        return _section('Registered tags (' + tags.length + ')', _listAsIndexedMap(tags), false);
+    }
+
+    function _registeredFeaturesSection(features) {
+        if (!Array.isArray(features) || !features.length) {
+            return null;
+        }
+        return _section('Registered features (' + features.length + ')', _listAsIndexedMap(features), false);
+    }
+
+    function _interopSection(primary) {
+        if (typeof primary.openUI5Detected !== 'boolean') {
+            return null;
+        }
+        var interop = {};
+        interop['OpenUI5 detected'] = primary.openUI5Detected;
+        if (typeof primary.openUI5LoadedFirst === 'boolean') {
+            interop['OpenUI5 loaded first'] = primary.openUI5LoadedFirst;
+        }
+        return _section('Interop', interop);
+    }
+
+    function _runtimesSection(runtimes) {
+        if (runtimes.length <= 1) {
+            return null;
+        }
+        var data = {};
+        for (var r = 0; r < runtimes.length; r++) {
+            var rt = runtimes[r];
+            data[r + 1] = (rt.alias ? rt.alias + ' — ' : '') +
+                (rt.description || ('version ' + (rt.version || 'unknown')));
+        }
+        return _section('Runtimes (' + runtimes.length + ')', data);
+    }
+
+    // Build application info in the same shape as classic UI5's
+    // applicationUtils.getApplicationInfo(). Surfaces what the framework
+    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
+    // configuration (theme, language, timezone, ...), registered tags and
+    // features, and a list of runtimes when more than one is active on the
+    // page.
+    function _buildApplicationInfo(frameworkInformation) {
+        var common = frameworkInformation.commonInformation;
+        var runtimes = (frameworkInformation.runtimes && frameworkInformation.runtimes.length) ?
+            frameworkInformation.runtimes : [];
+        var primary = runtimes[0] || {};
+        var sections = {
+            common: _generalSection(common),
+            configuration: _configurationSection(primary.configuration),
+            registeredTags: _registeredTagsSection(primary.registeredTags),
+            registeredFeatures: _registeredFeaturesSection(primary.registeredFeatures),
+            interop: _interopSection(primary),
+            runtimes: _runtimesSection(runtimes)
         };
+
+        var result = {};
+        var keys = Object.keys(sections);
+        for (var i = 0; i < keys.length; i++) {
+            if (sections[keys[i]]) {
+                result[keys[i]] = sections[keys[i]];
+            }
+        }
+        return result;
     }
 
     // Send the current control tree to the panel
@@ -319,6 +441,12 @@
         return visible || host;
     }
 
+    // Note: payload shapes vary per action because they are determined by
+    // the panel side, not by this script. Some actions ship the id as
+    // `event.detail.target`, others as `event.detail.data.controlId`,
+    // others as `event.detail.data` blobs. Matching the corresponding
+    // shape in injected/main.js keeps the message contracts identical
+    // across the two frameworks.
     var messageHandler = {
 
         'get-initial-information-webc': function () {

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -118,12 +118,33 @@
         return result;
     }
 
+    // Build application info in the same shape as classic UI5's applicationUtils.getApplicationInfo()
+    function _buildApplicationInfo(frameworkInformation) {
+        var common = frameworkInformation.commonInformation;
+        var general = {};
+        general[common.frameworkName] = common.version || '(unknown)';
+        general['User Agent'] = navigator.userAgent;
+        general.Application = location.href;
+
+        return {
+            common: {
+                options: {
+                    title: 'General',
+                    expandable: true,
+                    expanded: true
+                },
+                data: general
+            }
+        };
+    }
+
     // Send the current control tree to the panel
     function _sendTreeUpdate(action) {
         var controlTreeModel = WebCToolsAPI.getRenderedControlTree();
         WebCToolsAPI.getFrameworkInformation().then(function (frameworkInformation) {
             message.send({
                 action: action,
+                applicationInformation: _buildApplicationInfo(frameworkInformation),
                 controlTree: {
                     versionInfo: {
                         version: frameworkInformation.commonInformation.version,

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -7,6 +7,10 @@
     }
 
     var message = require('../modules/injected/message.js');
+    var highLighterModule = require('../modules/content/highLighter.js');
+    // Use a distinct wrapper id so this instance doesn't collide with the
+    // classic content-script highlighter on mixed pages.
+    var highlighter = highLighterModule.create({ wrapperId: 'ui5-highlighter-webc' });
 
     var TREE_UPDATE_DEBOUNCE_MS = 150;
 
@@ -167,7 +171,7 @@
             var isMutationValid = true;
 
             mutations.forEach(function (m) {
-                if (m.target.id === 'ui5-highlighter' || m.target.id === 'ui5-highlighter-container') {
+                if (m.target.id === 'ui5-highlighter' || m.target.id === 'ui5-highlighter-webc') {
                     isMutationValid = false;
                     return;
                 }
@@ -224,6 +228,54 @@
             controlEvents: _formatEvents(controlId, controlEvents),
             controlActions: _buildControlActions(controlId)
         });
+    }
+
+    // ================================================================================
+    // Helpers for resolving the visible representation of a hovered element.
+    // Some web components (e.g. ui5-breadcrumbs-item) are light-DOM data
+    // carriers with zero rect — the visible element lives inside the parent's
+    // shadow root, by convention with id `<itemId>-<suffix>`.
+    // ================================================================================
+
+    // Find an element inside `host`'s shadow root whose id starts with
+    // `idPrefix` and has a non-zero layout box.
+    function _findVisibleInShadow(host, idPrefix) {
+        var match = host.shadowRoot.querySelector('[id^="' + idPrefix + '"]');
+        if (!match) {
+            return null;
+        }
+        var rect = match.getBoundingClientRect();
+        return (rect.width || rect.height) ? match : null;
+    }
+
+    // Find a target that actually has a layout box. Used by the highlighter,
+    // which needs a non-zero rect to position its overlay.
+    function _resolveVisibleElement(element) {
+        if (!element) {
+            return null;
+        }
+        var rect = element.getBoundingClientRect();
+        if (rect.width || rect.height) {
+            return element;
+        }
+
+        // Walk up to find a shadow-root host and search by id-prefix
+        var id = element._id || element.id;
+        if (!id) {
+            return element;
+        }
+
+        var host = element.parentElement;
+        while (host && !host.shadowRoot) {
+            host = host.parentElement;
+        }
+        if (!host) {
+            return element;
+        }
+
+        var visible = _findVisibleInShadow(host, id);
+        // Fall back to the parent web component itself if no shadow match
+        return visible || host;
     }
 
     var messageHandler = {
@@ -287,8 +339,61 @@
                 // eslint-disable-next-line no-console
                 console.log(element.outerHTML);
             }
+        },
+
+        // Position the highlighter overlay on the hovered tree element. Uses
+        // WebCToolsAPI.getElementById (web component _id) instead of
+        // document.getElementById, which would only find DOM-id matches.
+        'on-control-tree-hover': function (event) {
+            var element = WebCToolsAPI.getElementById(event.detail.target);
+            if (!element) {
+                return;
+            }
+            highlighter.setDimensions(_resolveVisibleElement(element));
+        },
+
+        'on-hide-highlight': function () {
+            highlighter.hide();
+        },
+
+        // Selects the right-clicked element in the tree. Background broadcasts
+        // this when "Inspect UI5 element" is chosen from the context menu.
+        'do-context-menu-control-select': function (event) {
+            var target = event.detail.target;
+            // Only respond if the stored id belongs to a UI5 web component
+            if (!target || !WebCToolsAPI.getElementById(target)) {
+                return;
+            }
+            message.send({
+                action: 'on-contextMenu-control-select',
+                target: target,
+                frameId: event.detail.frameId
+            });
         }
     };
+
+    // ================================================================================
+    // Right-click capture: when the user right-clicks a UI5 web component, store
+    // its id so the background can hand it to the panel when "Inspect UI5 element"
+    // is selected from the context menu.
+    // ================================================================================
+    document.addEventListener('mousedown', function (event) {
+        if (event.button !== 2) {
+            return;
+        }
+        var target = event.target;
+        // Walk up to find the nearest UI5 web component ancestor
+        while (target && target !== document.body) {
+            if (target.isUI5Element === true) {
+                message.send({
+                    action: 'on-right-click',
+                    target: target._id || target.id
+                });
+                return;
+            }
+            target = target.parentNode;
+        }
+    }, true);
 
     document.addEventListener('ui5-communication-with-injected-script', function (event) {
         var action = event.detail.action;

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -1,0 +1,241 @@
+(function () {
+    'use strict';
+
+    var WebCToolsAPI = window.__ui5WebComponentsToolsAPI;
+    if (!WebCToolsAPI) {
+        return;
+    }
+
+    var message = require('../modules/injected/message.js');
+
+    var TREE_UPDATE_DEBOUNCE_MS = 150;
+
+    // Build the section title HTML used by all DataView formatters
+    function _buildSectionTitle(controlId, controlName) {
+        return '#<span class="controlId" data-control-id="' + controlId + '">' + controlId +
+            '</span><span gray>(' + controlName + ')</span>';
+    }
+
+    // Format properties for the DataView panel
+    function _formatProperties(controlId, properties) {
+        if (!properties || !properties.own) {
+            return {};
+        }
+
+        var title = properties.own.meta.controlName;
+        var props = properties.own.properties;
+        var formattedProps = Object.create(null);
+        var types = Object.create(null);
+
+        for (var key in props) {
+            formattedProps[key] = Object.create(null);
+            formattedProps[key].value = props[key].value;
+            formattedProps[key].isDefault = props[key].isDefault;
+            types[key] = props[key].type || 'string';
+        }
+
+        var result = Object.create(null);
+        result.isPropertiesData = true;
+        result.own = {
+            options: {
+                controlId: controlId,
+                expandable: false,
+                expanded: true,
+                title: _buildSectionTitle(controlId, title),
+                editableValues: true
+            },
+            data: formattedProps,
+            types: types
+        };
+        return result;
+    }
+
+    // Format aggregations (slots) for the DataView panel
+    function _formatAggregations(controlId, aggregations) {
+        if (!aggregations || !aggregations.own) {
+            return {};
+        }
+
+        var title = aggregations.own.meta.controlName;
+        var slots = aggregations.own.aggregations;
+        var formattedSlots = Object.create(null);
+
+        for (var key in slots) {
+            formattedSlots[key] = {
+                options: {
+                    title: key,
+                    expandable: true,
+                    expanded: !!slots[key].value,
+                    editableValues: false,
+                    showTypeInfo: true
+                },
+                data: {
+                    'content (id)': slots[key].value,
+                    'slot type': slots[key].type
+                }
+            };
+        }
+
+        var result = Object.create(null);
+        result.own = {
+            options: {
+                controlId: controlId,
+                expandable: false,
+                expanded: true,
+                title: _buildSectionTitle(controlId, title),
+                editableValues: false
+            },
+            data: formattedSlots
+        };
+        return result;
+    }
+
+    // Format events for the DataView panel
+    function _formatEvents(controlId, events) {
+        if (!events || !events.own) {
+            return {};
+        }
+
+        var title = events.own.meta.controlName;
+        var evts = events.own.events;
+        var formattedEvents = Object.create(null);
+
+        for (var key in evts) {
+            formattedEvents[key] = Object.create(null);
+        }
+
+        var result = Object.create(null);
+        result.own = {
+            options: {
+                controlId: controlId,
+                expandable: false,
+                expanded: true,
+                title: _buildSectionTitle(controlId, title),
+                editableValues: false
+            },
+            data: formattedEvents
+        };
+        return result;
+    }
+
+    // Send the current control tree to the panel
+    function _sendTreeUpdate(action) {
+        var controlTreeModel = WebCToolsAPI.getRenderedControlTree();
+        WebCToolsAPI.getFrameworkInformation().then(function (frameworkInformation) {
+            message.send({
+                action: action,
+                controlTree: {
+                    versionInfo: {
+                        version: frameworkInformation.commonInformation.version,
+                        framework: frameworkInformation.commonInformation.frameworkName
+                    },
+                    controls: controlTreeModel
+                }
+            });
+        });
+    }
+
+    var mutation = {
+        _pendingUpdate: 0,
+
+        init: function () {
+            this._observer.observe(document.body, this._options);
+        },
+
+        _observer: new MutationObserver(function (mutations) {
+            var isMutationValid = true;
+
+            mutations.forEach(function (m) {
+                if (m.target.id === 'ui5-highlighter' || m.target.id === 'ui5-highlighter-container') {
+                    isMutationValid = false;
+                    return;
+                }
+            });
+
+            if (!isMutationValid) {
+                return;
+            }
+
+            // Debounce: collapse rapid bursts of mutations into a single tree update
+            if (mutation._pendingUpdate) {
+                clearTimeout(mutation._pendingUpdate);
+            }
+            mutation._pendingUpdate = setTimeout(function () {
+                mutation._pendingUpdate = 0;
+                _sendTreeUpdate('on-application-dom-update-webc');
+            }, TREE_UPDATE_DEBOUNCE_MS);
+        }),
+
+        _options: {
+            subtree: true,
+            childList: true,
+            attributes: false
+        }
+    };
+
+    mutation.init();
+
+    function _sendControlSelectResponse(controlId) {
+        var controlProperties = WebCToolsAPI.getControlProperties(controlId);
+        var controlAggregations = WebCToolsAPI.getControlAggregations(controlId);
+        var controlEvents = WebCToolsAPI.getControlEvents(controlId);
+
+        message.send({
+            action: 'on-control-select',
+            controlProperties: _formatProperties(controlId, controlProperties),
+            controlBindings: {},
+            controlAggregations: _formatAggregations(controlId, controlAggregations),
+            controlEvents: _formatEvents(controlId, controlEvents),
+            controlActions: { actions: ['Focus'] }
+        });
+    }
+
+    var messageHandler = {
+
+        'get-initial-information-webc': function () {
+            _sendTreeUpdate('on-receiving-initial-data-webc');
+        },
+
+        'do-control-select-webc': function (event) {
+            var controlId = event.detail.target;
+            _sendControlSelectResponse(controlId);
+        },
+
+        'do-control-select': function (event) {
+            var controlId = event.detail.target;
+            if (!WebCToolsAPI.getElementById(controlId)) {
+                return;
+            }
+            _sendControlSelectResponse(controlId);
+        },
+
+        'do-control-property-change': function (event) {
+            var data = event.detail.data;
+            var controlId = data.controlId;
+            var element = WebCToolsAPI.getElementById(controlId);
+
+            if (!element) {
+                return;
+            }
+
+            // DataView capitalizes first letter (UI5 setter convention) — restore original casing
+            var property = data.property.charAt(0).toLowerCase() + data.property.slice(1);
+
+            try {
+                element[property] = data.value;
+            } catch (e) {
+                // silent
+            }
+
+            _sendControlSelectResponse(controlId);
+        }
+    };
+
+    document.addEventListener('ui5-communication-with-injected-script', function (event) {
+        var action = event.detail.action;
+
+        if (messageHandler[action]) {
+            messageHandler[action](event);
+        }
+    }, false);
+}());

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -1,3 +1,38 @@
+/**
+ * UI5 Web Components — page-side script for the UI5 Inspector.
+ *
+ * Runs in the inspected page's MAIN world (injected by the background
+ * service worker via chrome.scripting.executeScript with world: 'MAIN').
+ * Running in MAIN is required to see the framework's classes and the
+ * isUI5Element getter on elements; the chrome.* APIs are not used here.
+ *
+ * Communication
+ * -------------
+ * Page <-> DevTools panel messages are bridged via CustomEvents on
+ * `document`, forwarded by content/detectWebComponents.js (isolated world):
+ *
+ *   panel  -- port.postMessage -->  background
+ *   background  -- chrome.tabs.sendMessage -->  content/detectWebComponents.js
+ *   content  -- CustomEvent('ui5-communication-with-injected-script') -->  this script
+ *   this script  -- CustomEvent('ui5-communication-with-content-script') -->  content
+ *   content  -- port.postMessage -->  background  -->  panel
+ *
+ * Action names
+ * ------------
+ *  - `*-webc` actions are WebC-specific (e.g. get-initial-information-webc).
+ *  - Shared actions (do-control-select, do-control-focus,
+ *    do-copy-control-to-console, do-control-copy-html, do-control-property-change,
+ *    on-control-tree-hover, on-hide-highlight, do-context-menu-control-select)
+ *    are also handled by injected/main.js for classic UI5. Each handler
+ *    here guards on WebCToolsAPI.getElementById, so the two coexist
+ *    cleanly on mixed pages: only the script that recognises the id
+ *    responds.
+ *
+ * Introspection is delegated to window.__ui5WebComponentsToolsAPI
+ * (defined in vendor/WebComponentsToolsAPI.js, injected just before this
+ * script). The control tree is rebuilt on DOM mutations, debounced to
+ * collapse rapid bursts (e.g. animations) into a single update.
+ */
 (function () {
     'use strict';
 
@@ -237,10 +272,15 @@
     // shadow root, by convention with id `<itemId>-<suffix>`.
     // ================================================================================
 
-    // Find an element inside `host`'s shadow root whose id starts with
-    // `idPrefix` and has a non-zero layout box.
-    function _findVisibleInShadow(host, idPrefix) {
-        var match = host.shadowRoot.querySelector('[id^="' + idPrefix + '"]');
+    // Find an element inside `host`'s shadow root whose id exactly equals
+    // `id` or begins with `id-` (the framework convention for derived ids,
+    // e.g. ui5wc_104 -> ui5wc_104-link-wrapper). We avoid a plain prefix
+    // match like `[id^="ui5wc_1"]` because it also matches ui5wc_10,
+    // ui5wc_100, etc. The selected match must have a non-zero layout box.
+    function _findVisibleInShadow(host, id) {
+        var match = host.shadowRoot.querySelector(
+            '[id="' + id + '"], [id^="' + id + '-"]'
+        );
         if (!match) {
             return null;
         }
@@ -385,9 +425,10 @@
         // Walk up to find the nearest UI5 web component ancestor
         while (target && target !== document.body) {
             if (target.isUI5Element === true) {
+                // UI5Element guarantees _id (lazy getter, see UI5Element.ts)
                 message.send({
                     action: 'on-right-click',
-                    target: target._id || target.id
+                    target: target._id
                 });
                 return;
             }

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -9,10 +9,10 @@
  * Communication
  * -------------
  * Page <-> DevTools panel messages are bridged via CustomEvents on
- * `document`, forwarded by content/detectWebComponents.js (isolated world):
+ * `document`, forwarded by content/webcMain.js (isolated world):
  *
  *   panel  -- port.postMessage -->  background
- *   background  -- chrome.tabs.sendMessage -->  content/detectWebComponents.js
+ *   background  -- chrome.tabs.sendMessage -->  content/webcMain.js
  *   content  -- CustomEvent('ui5-communication-with-injected-script') -->  this script
  *   this script  -- CustomEvent('ui5-communication-with-content-script') -->  content
  *   content  -- port.postMessage -->  background  -->  panel

--- a/app/scripts/modules/content/highLighter.ts
+++ b/app/scripts/modules/content/highLighter.ts
@@ -1,84 +1,84 @@
 'use strict';
 
 /**
- * Singleton helper to highlight controls DOM elements
+ * Factory for highlighter overlays. Each call returns an independent
+ * instance with its own wrapper element, so multiple instances (e.g. one
+ * for classic UI5, one for UI5 Web Components) can coexist on a page.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.wrapperId='ui5-highlighter'] - DOM id of the
+ *     wrapper div. Use distinct ids when more than one highlighter shares
+ *     a page so they don't collide.
  */
-var Highlighter = {
-    // Reference for the highlighter DOM element
-    _highLighterDomEl: null,
+function createHighlighter(options) {
+    var wrapperId = (options && options.wrapperId) || 'ui5-highlighter';
+    var wrapper = null;
 
-    /**
-     * Hide the highlighter.
-     * @public
-     */
-    hide: function () {
-        this._highLighterDomEl && (this._highLighterDomEl.style.display = 'none');
-    },
+    function _create() {
+        var inner = document.createElement('div');
+        inner.style.cssText = 'box-sizing: border-box;border:1px solid blue;background: rgba(20, 20, 200, 0.4);position: absolute';
 
-    /**
-     * Show the highlighter.
-     * @private
-     */
-    _show: function () {
-        this._highLighterDomEl && (this._highLighterDomEl.style.display = 'block');
-    },
+        var w = document.createElement('div');
+        w.id = wrapperId;
+        w.style.cssText = 'position: fixed;top:0;right:0;bottom:0;left:0;z-index: 1000;overflow: hidden;pointer-events: none;';
+        w.appendChild(inner);
 
-    /**
-     * Create DOM element for visual highlighting.
-     * @private
-     */
-    _create: function () {
-        var highLighter = document.createElement('div');
-        highLighter.style.cssText = 'box-sizing: border-box;border:1px solid blue;background: rgba(20, 20, 200, 0.4);position: absolute';
+        document.body.appendChild(w);
 
-        var highLighterWrapper = document.createElement('div');
-        highLighterWrapper.id = 'ui5-highlighter';
-        highLighterWrapper.style.cssText = 'position: fixed;top:0;right:0;bottom:0;left:0;z-index: 1000;overflow: hidden;';
-        highLighterWrapper.appendChild(highLighter);
-
-        document.body.appendChild(highLighterWrapper);
-
-        // Save reference for later usage
-        this._highLighterDomEl = document.getElementById('ui5-highlighter');
-
-        // Add event handler
-        this._highLighterDomEl.onmouseover = this.hide.bind(this);
-    },
-
-    /**
-     * Set the position of the visual highlighter.
-     * @param {string} elementId - The id of the DOM element that need to be highlighted
-     * @returns {exports}
-     */
-    setDimensions: function (elementId) {
-        var highlighter;
-        var targetDomElement;
-        var targetRect;
-
-        // the hightlighter DOM element may already have been created in a previous DevTools session
-        // (followed by closing and reopening the DevTools)
-        this._highLighterDomEl || (this._highLighterDomEl = document.getElementById('ui5-highlighter'));
-
-        if (!this._highLighterDomEl) {
-            this._create();
-        } else {
-            this._show();
-        }
-
-        highlighter = this._highLighterDomEl.firstElementChild;
-        targetDomElement = document.getElementById(elementId);
-
-        if (targetDomElement) {
-            targetRect = targetDomElement.getBoundingClientRect();
-
-            highlighter.style.top = targetRect.top + 'px';
-            highlighter.style.left = targetRect.left + 'px';
-            highlighter.style.height = targetRect.height + 'px';
-            highlighter.style.width = targetRect.width + 'px';
-        }
-
-        return this;
+        // Hide on mouseover so the user can interact with the page underneath
+        w.onmouseover = hide;
+        wrapper = w;
     }
-};
 
-module.exports = Highlighter;
+    function _ensure() {
+        // Pick up an existing wrapper from a previous DevTools session
+        // (e.g. user closed and reopened DevTools)
+        if (!wrapper || !wrapper.isConnected) {
+            wrapper = document.getElementById(wrapperId);
+        }
+        if (!wrapper) {
+            _create();
+        }
+    }
+
+    /**
+     * Position the overlay over the given element. The element is resolved
+     * by the caller — this module does not look ids up, since classic UI5
+     * uses DOM ids and web components use a framework-assigned _id.
+     * @param {Element} element
+     */
+    function setDimensions(element) {
+        _ensure();
+
+        var inner = wrapper.firstElementChild;
+
+        if (!element) {
+            // No target — leave the wrapper visible but clear the inner box,
+            // matching the legacy behavior.
+            return;
+        }
+
+        wrapper.style.display = 'block';
+
+        var rect = element.getBoundingClientRect();
+        inner.style.top = rect.top + 'px';
+        inner.style.left = rect.left + 'px';
+        inner.style.height = rect.height + 'px';
+        inner.style.width = rect.width + 'px';
+    }
+
+    function hide() {
+        if (wrapper) {
+            wrapper.style.display = 'none';
+        }
+    }
+
+    return {
+        setDimensions: setDimensions,
+        hide: hide
+    };
+}
+
+module.exports = {
+    create: createHighlighter
+};

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -94,33 +94,6 @@
         return 'string';
     }
 
-    // Resolve the framework-applied default for a property by reading it from
-    // the prototype chain BEFORE the instance has overridden it. With TS class
-    // field initializers the default ends up on the instance (`Object.hasOwn`),
-    // but with the framework's converter pattern it's typically on the
-    // prototype. We approximate by walking up the prototype chain looking for
-    // the first defined value; if none, fall back to type-based defaults.
-    function _getDefaultValue(element, propName, type) {
-        var proto = Object.getPrototypeOf(element);
-        while (proto && proto !== HTMLElement.prototype && proto !== Object.prototype) {
-            var desc = Object.getOwnPropertyDescriptor(proto, propName);
-            if (desc) {
-                if ('value' in desc) {
-                    return desc.value;
-                }
-                // It's a getter — can't safely invoke without side-effects, give up
-                break;
-            }
-            proto = Object.getPrototypeOf(proto);
-        }
-        // Type-based fallback (matches what the framework uses when no default
-        // is declared; see the defaultConverter in UI5Element.ts).
-        if (type === 'boolean') { return false; }
-        if (type === 'number') { return 0; }
-        if (type === 'string') { return ''; }
-        return undefined;
-    }
-
     // Slot mapping: a slot's content is exposed on the element under a
     // `propertyName` (defaults to the slot name). The framework populates
     // `element[propertyName]` with the array of assigned nodes.
@@ -187,14 +160,16 @@
                 if (key.charAt(0) === '_') {
                     continue;
                 }
-                var propType = _getPropertyType(propsMetadata[key]);
-                var currentValue = element[key];
-                var defaultValue = _getDefaultValue(element, key, propType);
-
+                // Note: `isDefault` is intentionally not reported. Web
+                // components has no declared `defaultValue` in metadata, and
+                // class field initializers compiled to ES2022 land on the
+                // instance, so we cannot reliably distinguish the framework
+                // default from a user-set value. A future implementation
+                // could snapshot defaults by sampling a fresh
+                // document.createElement(tag) per tag at startup.
                 result.own.properties[key] = Object.create(null);
-                result.own.properties[key].value = currentValue;
-                result.own.properties[key].type = propType;
-                result.own.properties[key].isDefault = currentValue === defaultValue;
+                result.own.properties[key].value = element[key];
+                result.own.properties[key].type = _getPropertyType(propsMetadata[key]);
             }
 
             result.inherited = [];

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -122,14 +122,37 @@
         return slotData.type === Node ? 'Node' : 'HTMLElement';
     }
 
+    // Returns the array of runtime descriptors the framework registers on the
+    // shared-resources meta element. See packages/base/src/Runtimes.ts.
+    // Each runtime exposes: version, alias, description, registeredTags,
+    // registeredFeatures, configuration (theme, language, timezone, etc.),
+    // openUI5Detected, openUI5LoadedFirst, and more. Returns [] if the
+    // meta element or Runtimes property is missing.
+    function _getRuntimes() {
+        try {
+            var meta = document.querySelector('meta[name="ui5-shared-resources"]');
+            if (meta && Array.isArray(meta.Runtimes)) {
+                return meta.Runtimes;
+            }
+        } catch (e) {
+            // best-effort
+        }
+        return [];
+    }
+
     window.__ui5WebComponentsToolsAPI = {
 
         getFrameworkInformation: function () {
+            var runtimes = _getRuntimes();
+            var primary = runtimes[0] || {};
             return Promise.resolve({
                 commonInformation: {
                     frameworkName: 'UI5 Web Components',
-                    version: _getVersion()
-                }
+                    version: _getVersion(),
+                    buildTime: primary.buildTime,
+                    description: primary.description
+                },
+                runtimes: runtimes
             });
         },
 

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -1,0 +1,231 @@
+(function () {
+    'use strict';
+
+    var elementMap = Object.create(null);
+    var cachedVersion = null;
+
+    function _isUI5WebComponent(element) {
+        return element.localName.indexOf('-') !== -1 &&
+            element.constructor &&
+            typeof element.constructor.getMetadata === 'function';
+    }
+
+    function _getVersion() {
+        if (cachedVersion !== null) {
+            return cachedVersion;
+        }
+        cachedVersion = '';
+        try {
+            var meta = document.querySelector('meta[name="ui5-shared-resources"]');
+            if (!meta) {
+                return cachedVersion;
+            }
+            var content = meta.getAttribute('data-ui5-shared-resources-runtimes');
+            if (content) {
+                var runtimes = JSON.parse(content);
+                if (runtimes.length > 0 && runtimes[0].version) {
+                    cachedVersion = runtimes[0].version;
+                }
+            }
+        } catch (e) {
+            // best-effort
+        }
+        return cachedVersion;
+    }
+
+    function _getElementId(element) {
+        return element.id || element._id || element.__id || ('webc_' + Array.prototype.indexOf.call(
+            document.querySelectorAll(element.localName), element
+        ));
+    }
+
+    function _buildTreeRecursive(parentElement) {
+        var children = parentElement.children;
+        var result = [];
+
+        for (var i = 0; i < children.length; i++) {
+            var child = children[i];
+            if (_isUI5WebComponent(child)) {
+                var id = _getElementId(child);
+                elementMap[id] = child;
+                var node = {
+                    id: id,
+                    name: child.localName,
+                    type: 'ui5-web-component',
+                    content: _buildTreeRecursive(child)
+                };
+                result.push(node);
+            } else {
+                var nested = _buildTreeRecursive(child);
+                for (var j = 0; j < nested.length; j++) {
+                    result.push(nested[j]);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    function _getPropertyType(propMeta) {
+        if (!propMeta || !propMeta.type) {
+            return 'string';
+        }
+        var t = propMeta.type;
+        if (t === Boolean || t === window.Boolean) return 'boolean';
+        if (t === Number || t === window.Number) return 'number';
+        if (t === String || t === window.String) return 'string';
+        if (t === Object || t === window.Object) return 'object';
+        if (t === Array || t === window.Array) return 'array';
+        return 'string';
+    }
+
+    function _getDefaultValue(type) {
+        if (type === 'boolean') return false;
+        if (type === 'number') return 0;
+        if (type === 'string') return '';
+        if (type === 'object') return undefined;
+        if (type === 'array') return undefined;
+        return undefined;
+    }
+
+    window.__ui5WebComponentsToolsAPI = {
+
+        getFrameworkInformation: function () {
+            return Promise.resolve({
+                commonInformation: {
+                    frameworkName: 'UI5 Web Components',
+                    version: _getVersion()
+                }
+            });
+        },
+
+        getRenderedControlTree: function () {
+            elementMap = Object.create(null);
+            return _buildTreeRecursive(document.body);
+        },
+
+        getControlProperties: function (controlId) {
+            var element = elementMap[controlId];
+            if (!element) {
+                return {};
+            }
+
+            var metadata = element.constructor.getMetadata();
+            var propsMetadata = metadata.getProperties();
+            var result = Object.create(null);
+
+            result.own = Object.create(null);
+            result.own.meta = Object.create(null);
+            result.own.meta.controlName = metadata.getTag ? metadata.getTag() : element.localName;
+
+            result.own.properties = Object.create(null);
+            var propNames = Object.keys(propsMetadata);
+            for (var i = 0; i < propNames.length; i++) {
+                var key = propNames[i];
+                // Skip private properties (internal implementation details)
+                if (key.charAt(0) === '_') {
+                    continue;
+                }
+                var propType = _getPropertyType(propsMetadata[key]);
+                var currentValue = element[key];
+                var defaultValue = _getDefaultValue(propType);
+
+                result.own.properties[key] = Object.create(null);
+                result.own.properties[key].value = currentValue;
+                result.own.properties[key].type = propType;
+                result.own.properties[key].isDefault = currentValue === defaultValue;
+            }
+
+            result.inherited = [];
+            result.isPropertiesData = true;
+
+            return result;
+        },
+
+        getControlAggregations: function (controlId) {
+            var element = elementMap[controlId];
+            if (!element) {
+                return {};
+            }
+
+            var metadata = element.constructor.getMetadata();
+            var slotsMetadata = metadata.getSlots();
+            var result = Object.create(null);
+
+            result.own = Object.create(null);
+            result.own.meta = Object.create(null);
+            result.own.meta.controlName = metadata.getTag ? metadata.getTag() : element.localName;
+
+            result.own.aggregations = Object.create(null);
+            var slotNames = Object.keys(slotsMetadata);
+            for (var i = 0; i < slotNames.length; i++) {
+                var slotName = slotNames[i];
+                // Skip private slots
+                if (slotName.charAt(0) === '_') {
+                    continue;
+                }
+                var slotData = slotsMetadata[slotName];
+                var slottedContent;
+
+                try {
+                    if (typeof element.getSlottedNodes === 'function') {
+                        var nodes = element.getSlottedNodes(slotName);
+                        slottedContent = nodes.map(function (n) {
+                            return _getElementId(n) || n.localName;
+                        });
+                    } else {
+                        slottedContent = [];
+                    }
+                } catch (e) {
+                    slottedContent = [];
+                }
+
+                result.own.aggregations[slotName] = Object.create(null);
+                result.own.aggregations[slotName].value = slottedContent.length > 0 ? slottedContent : null;
+                result.own.aggregations[slotName].type = slotData.type === Node ? 'Node' : 'HTMLElement';
+            }
+
+            result.inherited = [];
+            return result;
+        },
+
+        getControlBindings: function () {
+            return Object.create(null);
+        },
+
+        getControlEvents: function (controlId) {
+            var element = elementMap[controlId];
+            if (!element) {
+                return {};
+            }
+
+            var metadata = element.constructor.getMetadata();
+            var eventsMetadata = metadata.getEvents();
+            var result = Object.create(null);
+
+            result.own = Object.create(null);
+            result.own.meta = Object.create(null);
+            result.own.meta.controlName = metadata.getTag ? metadata.getTag() : element.localName;
+
+            result.own.events = Object.create(null);
+            var eventNames = Object.keys(eventsMetadata);
+            for (var i = 0; i < eventNames.length; i++) {
+                var eventName = eventNames[i];
+                // Skip private events
+                if (eventName.charAt(0) === '_') {
+                    continue;
+                }
+                result.own.events[eventName] = Object.create(null);
+                result.own.events[eventName].paramsType = Object.create(null);
+                result.own.events[eventName].registry = null;
+            }
+
+            result.inherited = [];
+            return result;
+        },
+
+        getElementById: function (id) {
+            return elementMap[id] || null;
+        }
+    };
+}());

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -4,10 +4,10 @@
     var elementMap = Object.create(null);
     var cachedVersion = null;
 
+    // A UI5 web component exposes the `isUI5Element` getter (returns true).
+    // See packages/base/src/UI5Element.ts (get isUI5Element).
     function _isUI5WebComponent(element) {
-        return element.localName.indexOf('-') !== -1 &&
-            element.constructor &&
-            typeof element.constructor.getMetadata === 'function';
+        return element && element.isUI5Element === true;
     }
 
     function _getVersion() {
@@ -20,12 +20,12 @@
             if (!meta) {
                 return cachedVersion;
             }
-            var content = meta.getAttribute('data-ui5-shared-resources-runtimes');
-            if (content) {
-                var runtimes = JSON.parse(content);
-                if (runtimes.length > 0 && runtimes[0].version) {
-                    cachedVersion = runtimes[0].version;
-                }
+
+            // Web components stores runtime info as a JS property `Runtimes`
+            // on the meta element (an Array of runtime objects).
+            // See packages/base/src/Runtimes.ts.
+            if (meta.Runtimes && meta.Runtimes.length > 0 && meta.Runtimes[0].version) {
+                cachedVersion = meta.Runtimes[0].version;
             }
         } catch (e) {
             // best-effort
@@ -33,10 +33,21 @@
         return cachedVersion;
     }
 
+    // Returns the canonical id used by the framework: `_id` is a getter that
+    // lazily assigns `ui5wc_<n>` and stores it in `__id`. Falls back to the
+    // author-set id (DOM `id` attribute) if present.
+    // See packages/base/src/UI5Element.ts (get _id).
     function _getElementId(element) {
-        return element.id || element._id || element.__id || ('webc_' + Array.prototype.indexOf.call(
+        if (element.id) {
+            return element.id;
+        }
+        if (element._id) {
+            return element._id;
+        }
+        // Last resort for non-UI5 nodes (e.g., when reporting a slotted plain element)
+        return 'webc_' + Array.prototype.indexOf.call(
             document.querySelectorAll(element.localName), element
-        ));
+        );
     }
 
     function _buildTreeRecursive(parentElement) {
@@ -66,26 +77,76 @@
         return result;
     }
 
+    // Property metadata uses constructor references for `type`:
+    // {type: Boolean | String | Number | Object | Array}.
+    // See packages/base/src/UI5ElementMetadata.ts (Property).
     function _getPropertyType(propMeta) {
         if (!propMeta || !propMeta.type) {
+            // Default per the framework's defaultConverter is String.
             return 'string';
         }
         var t = propMeta.type;
-        if (t === Boolean || t === window.Boolean) return 'boolean';
-        if (t === Number || t === window.Number) return 'number';
-        if (t === String || t === window.String) return 'string';
-        if (t === Object || t === window.Object) return 'object';
-        if (t === Array || t === window.Array) return 'array';
+        if (t === Boolean) { return 'boolean'; }
+        if (t === Number) { return 'number'; }
+        if (t === String) { return 'string'; }
+        if (t === Object) { return 'object'; }
+        if (t === Array) { return 'array'; }
         return 'string';
     }
 
-    function _getDefaultValue(type) {
-        if (type === 'boolean') return false;
-        if (type === 'number') return 0;
-        if (type === 'string') return '';
-        if (type === 'object') return undefined;
-        if (type === 'array') return undefined;
+    // Resolve the framework-applied default for a property by reading it from
+    // the prototype chain BEFORE the instance has overridden it. With TS class
+    // field initializers the default ends up on the instance (`Object.hasOwn`),
+    // but with the framework's converter pattern it's typically on the
+    // prototype. We approximate by walking up the prototype chain looking for
+    // the first defined value; if none, fall back to type-based defaults.
+    function _getDefaultValue(element, propName, type) {
+        var proto = Object.getPrototypeOf(element);
+        while (proto && proto !== HTMLElement.prototype && proto !== Object.prototype) {
+            var desc = Object.getOwnPropertyDescriptor(proto, propName);
+            if (desc) {
+                if ('value' in desc) {
+                    return desc.value;
+                }
+                // It's a getter — can't safely invoke without side-effects, give up
+                break;
+            }
+            proto = Object.getPrototypeOf(proto);
+        }
+        // Type-based fallback (matches what the framework uses when no default
+        // is declared; see the defaultConverter in UI5Element.ts).
+        if (type === 'boolean') { return false; }
+        if (type === 'number') { return 0; }
+        if (type === 'string') { return ''; }
         return undefined;
+    }
+
+    // Slot mapping: a slot's content is exposed on the element under a
+    // `propertyName` (defaults to the slot name). The framework populates
+    // `element[propertyName]` with the array of assigned nodes.
+    // See packages/base/src/UI5Element.ts (_state[propertyName]) and
+    // packages/base/src/UI5ElementMetadata.ts (Slot.propertyName).
+    function _getSlottedContent(element, slotName, slotData) {
+        var propertyName = slotData.propertyName || slotName;
+        var nodes = element[propertyName];
+        if (!Array.isArray(nodes)) {
+            return [];
+        }
+        var ids = [];
+        for (var i = 0; i < nodes.length; i++) {
+            var n = nodes[i];
+            if (n) {
+                ids.push(_getElementId(n) || n.localName || '<node>');
+            }
+        }
+        return ids;
+    }
+
+    function _getSlotTypeName(slotData) {
+        if (!slotData || !slotData.type) {
+            return 'HTMLElement';
+        }
+        return slotData.type === Node ? 'Node' : 'HTMLElement';
     }
 
     window.__ui5WebComponentsToolsAPI = {
@@ -128,7 +189,7 @@
                 }
                 var propType = _getPropertyType(propsMetadata[key]);
                 var currentValue = element[key];
-                var defaultValue = _getDefaultValue(propType);
+                var defaultValue = _getDefaultValue(element, key, propType);
 
                 result.own.properties[key] = Object.create(null);
                 result.own.properties[key].value = currentValue;
@@ -165,34 +226,25 @@
                     continue;
                 }
                 var slotData = slotsMetadata[slotName];
-                var slottedContent;
-
-                try {
-                    if (typeof element.getSlottedNodes === 'function') {
-                        var nodes = element.getSlottedNodes(slotName);
-                        slottedContent = nodes.map(function (n) {
-                            return _getElementId(n) || n.localName;
-                        });
-                    } else {
-                        slottedContent = [];
-                    }
-                } catch (e) {
-                    slottedContent = [];
-                }
+                var slottedContent = _getSlottedContent(element, slotName, slotData);
 
                 result.own.aggregations[slotName] = Object.create(null);
                 result.own.aggregations[slotName].value = slottedContent.length > 0 ? slottedContent : null;
-                result.own.aggregations[slotName].type = slotData.type === Node ? 'Node' : 'HTMLElement';
+                result.own.aggregations[slotName].type = _getSlotTypeName(slotData);
             }
 
             result.inherited = [];
             return result;
         },
 
+        // Web components has no concept of bindings; return empty.
         getControlBindings: function () {
             return Object.create(null);
         },
 
+        // Event metadata shape: {detail?, bubbles, cancelable}.
+        // See packages/base/src/UI5ElementMetadata.ts (EventData) and
+        // packages/base/src/decorators/event.ts.
         getControlEvents: function (controlId) {
             var element = elementMap[controlId];
             if (!element) {
@@ -215,8 +267,22 @@
                 if (eventName.charAt(0) === '_') {
                     continue;
                 }
+                var eventData = eventsMetadata[eventName] || {};
+                // Build a paramsType map from the event's `detail` declaration
+                var paramsType = Object.create(null);
+                if (eventData.detail) {
+                    var detailKeys = Object.keys(eventData.detail);
+                    for (var j = 0; j < detailKeys.length; j++) {
+                        var paramKey = detailKeys[j];
+                        var paramMeta = eventData.detail[paramKey];
+                        // detail values can be {type: <ctor>} or just metadata objects
+                        paramsType[paramKey] = paramMeta && paramMeta.type
+                            ? (paramMeta.type.name || String(paramMeta.type))
+                            : '';
+                    }
+                }
                 result.own.events[eventName] = Object.create(null);
-                result.own.events[eventName].paramsType = Object.create(null);
+                result.own.events[eventName].paramsType = paramsType;
                 result.own.events[eventName].registry = null;
             }
 

--- a/tests/modules/content/highLighter.spec.js
+++ b/tests/modules/content/highLighter.spec.js
@@ -1,70 +1,95 @@
 'use strict';
 
-// TODO the highLighter module needs refactoring
-var highLighter = require('../../../app/scripts/modules/content/highLighter.ts');
+var highLighterModule = require('../../../app/scripts/modules/content/highLighter.ts');
 
 describe('highLighter', function () {
-    it('should return a object', function () {
-        highLighter.should.be.a('object');
+    it('should expose a create() factory', function () {
+        highLighterModule.should.be.a('object');
+        highLighterModule.create.should.be.a('function');
     });
 
     describe('#setDimensions()', function () {
         var fixtures = document.getElementById('fixtures');
+        var highLighter;
+        var target;
 
         before(function () {
             fixtures.innerHTML = '<div id="shell" style="width: 50px; height: 50px;"></div>';
+            target = document.getElementById('shell');
+            highLighter = highLighterModule.create();
         });
 
         after(function () {
             fixtures.innerHTML = '';
-            document.getElementById('ui5-highlighter').parentNode.removeChild(document.getElementById('ui5-highlighter'));
+            var wrapper = document.getElementById('ui5-highlighter');
+            if (wrapper) {
+                wrapper.parentNode.removeChild(wrapper);
+            }
         });
 
-        it('should create a DOM elements', function () {
-            highLighter.setDimensions('shell');
+        it('should create the wrapper DOM elements on first call', function () {
+            highLighter.setDimensions(target);
 
             document.body.querySelector('#ui5-highlighter').should.exist;
             document.body.querySelector('#ui5-highlighter > div').should.exist;
         });
 
-        it('should set proper sizes to the "#ui5-highlighter > div" element', function () {
-            highLighter.setDimensions('shell');
+        it('should set sizes on the inner element matching the target rect', function () {
+            highLighter.setDimensions(target);
 
             document.body.querySelector('#ui5-highlighter > div').style.width.should.equal('50px');
             document.body.querySelector('#ui5-highlighter > div').style.height.should.equal('50px');
         });
 
         it('should position the inner div according to target', function () {
-            var mock = document.getElementById('shell').getBoundingClientRect();
-            highLighter.setDimensions('shell');
+            var rect = target.getBoundingClientRect();
+            highLighter.setDimensions(target);
 
-            document.body.querySelector('#ui5-highlighter > div').style.top.should.equal(mock.top + 'px');
-            document.body.querySelector('#ui5-highlighter > div').style.left.should.equal(mock.left + 'px');
+            document.body.querySelector('#ui5-highlighter > div').style.top.should.equal(rect.top + 'px');
+            document.body.querySelector('#ui5-highlighter > div').style.left.should.equal(rect.left + 'px');
         });
 
-        it('should not add CSS styles if the target can not be found', function () {
-            document.body.querySelector('#ui5-highlighter > div').removeAttribute('style');
-            highLighter.setDimensions('shell-mock');
+        it('should not change CSS styles when called with no element', function () {
+            highLighter.setDimensions(target);
+            var inner = document.body.querySelector('#ui5-highlighter > div');
+            var widthBefore = inner.style.width;
+            var heightBefore = inner.style.height;
+            var topBefore = inner.style.top;
+            var leftBefore = inner.style.left;
 
-            document.body.querySelector('#ui5-highlighter > div').style.width.should.equal('');
-            document.body.querySelector('#ui5-highlighter > div').style.height.should.equal('');
-            document.body.querySelector('#ui5-highlighter > div').style.top.should.equal('');
-            document.body.querySelector('#ui5-highlighter > div').style.left.should.equal('');
+            highLighter.setDimensions(null);
+
+            inner.style.width.should.equal(widthBefore);
+            inner.style.height.should.equal(heightBefore);
+            inner.style.top.should.equal(topBefore);
+            inner.style.left.should.equal(leftBefore);
         });
 
         it('should hide the highlighter on hover', function () {
-            highLighter.setDimensions('shell');
+            highLighter.setDimensions(target);
             document.body.querySelector('#ui5-highlighter').onmouseover();
 
             document.body.querySelector('#ui5-highlighter').style.display.should.equal('none');
         });
 
-        it('should create only one highlighter', function () {
-            highLighter.setDimensions('shell');
-            highLighter.setDimensions('shell');
+        it('should reuse a single wrapper across calls', function () {
+            highLighter.setDimensions(target);
+            highLighter.setDimensions(target);
 
             document.body.querySelectorAll('#ui5-highlighter').length.should.equal(1);
         });
 
+        it('should accept a custom wrapperId for distinct instances', function () {
+            var other = highLighterModule.create({ wrapperId: 'ui5-highlighter-other' });
+            other.setDimensions(target);
+
+            document.body.querySelector('#ui5-highlighter-other').should.exist;
+
+            // cleanup
+            var w = document.getElementById('ui5-highlighter-other');
+            if (w) {
+                w.parentNode.removeChild(w);
+            }
+        });
     });
 });


### PR DESCRIPTION
Extends the UI5 Inspector to detect and inspect UI5 Web Components-based applications, alongside the existing OpenUI5/SAPUI5 support. Pages using either framework — or both — show a merged control tree with per-framework introspection.

------------------------------------------------------------------------------------------------------------

**What's implemented**

**Detection**. Pages using @ui5/webcomponents are detected automatically alongside classic UI5 detection. Mixed pages report both.

**Control tree**. Web components are listed alongside classic UI5 controls. On mixed pages the two are merged under a single tree, with the WebC portion grouped under a synthetic root labelled with the framework name and version. Private members (names beginning with _) are filtered from properties, slots, and events to keep the panel focused on the public API. Tree updates on DOM changes are debounced (150 ms) to collapse rapid bursts.

**Properties tab**. Reads property metadata via element.constructor.getMetadata() and current values from the live element. Editable inline (writes back via element[name] = value).

**Slots tab**. On pure WebC pages the "Aggregations" tab label is renamed to "Slots". Slotted content is resolved via element[slotData.propertyName || slotName] (how the framework itself exposes slot assignments), so nested elements are surfaced with their _ids.

**Events tab**. Lists declared events; when an event's metadata declares a detail shape, param types are reported.

**Actions tab**. Focus, Copy to Console, Copy HTML to Console. Invalidate is intentionally omitted — web components re-render automatically on property/attribute changes.

**App Info tab (pure WebC)**. General, Configuration (theme, language, timezone, animation mode, calendar type, etc.), Registered tags, Registered features, Interop (OpenUI5 detection), Runtimes (when more than one is active). Data comes from meta.Runtimes[0] (packages/base/src/Runtimes.ts). Long lists (registered tags, features) are alphabetised and emitted as arrays so DataView preserves order.

**Right-click "Inspect UI5 element**" in the page selects the corresponding row in the tree. The context menu label was renamed from "Inspect UI5 control" since "control" is SAPUI5 terminology.

**Tree hover highlight** overlays the visible element on the page. Some components (e.g. ui5-breadcrumbs-item) are light-DOM data carriers with zero rect; the highlighter walks up to the shadow root and resolves the visible representation by the framework's <itemId>-<suffix> convention.

------------------------------------------------------------------------------------------------------------

**Architecture**

The existing 4-layer communication (panel ↔ background ↔ content script ↔ page-injected script) was fully reusable, and the WebC scripts follow the same lifecycle as classic UI5. New pieces:

**app/vendor/WebComponentsToolsAPI.js** — introspection API. Exposes getFrameworkInformation, getRenderedControlTree, getControlProperties, getControlAggregations, getControlEvents, getElementById. Aligned with the framework source (UI5Element.ts, UI5ElementMetadata.ts): identifies web components via element.isUI5Element === true, reads the framework version from meta.Runtimes[0].version, uses element._id as the canonical id.
**app/scripts/injected/detectWebComponents.js** — page-context detector (symmetric to injected/detectUI5.js).
**app/scripts/content/detectWebComponents.js** — always-on content script that injects the detector and forwards detection results (symmetric to content/detectUI5.js). It only participates until detection completes, then drops out of the message path.
**app/scripts/content/webcMain.js** — content-script message bridge between the background and the MAIN-world script, injected on demand after detection (symmetric to content/main.js). Includes a DONE_FLAG guard to avoid duplicate listeners when DevTools are undocked/redocked.
**app/scripts/injected/webcMain.js** — MAIN-world script that handles all runtime interactions (tree updates, property edits, focus, copy, right-click, tree hover). A top-of-file block comment documents the communication path and action-name conventions.

The WebC tools API and handler are injected into the page's MAIN world via chrome.scripting.executeScript({ world: 'MAIN' }), since they need to see the framework's classes and the isUI5Element getter on elements. The message bridge (content/webcMain.js) is injected into the isolated world, exactly as content/main.js is for classic UI5.

------------------------------------------------------------------------------------------------------------

**Panel changes**

- New message handlers: on-webc-detected, on-webc-not-detected, on-webc-script-injection, on-receiving-initial-data-webc, on-application-dom-update-webc.
- Tree merging (_getMergedControlTree) combines classic + WebC trees into one view.
- The "Aggregations" tab label is renamed to "Slots" dynamically when the current frame is pure WebC.
- App Info precedence rule on mixed pages: classic UI5 wins, since it provides richer info (loaded libraries, modules, bootstrap config, URL parameters); documented inline where the rule is applied.
- The synthetic WebC group root (__webc_root__) is non-selectable and non-hoverable — its handlers no-op when the id matches.
- Overlay text mentions UI5 Web Components alongside OpenUI5/SAPUI5.

------------------------------------------------------------------------------------------------------------

**Shared highlighter refactor**

modules/content/highLighter.ts was refactored from a singleton with id-based lookup to a factory taking a resolved element:

- Classic content script: highLighter.setDimensions(document.getElementById(id)).
- WebC script: highLighter.setDimensions(WebCToolsAPI.getElementById(id)).
- Two instances coexist on mixed pages via distinct wrapperId options (ui5-highlighter and ui5-highlighter-webc) so their overlays don't collide.
- The existing highLighter.spec.js was updated to cover the new API (factory, element param, custom wrapper id).

------------------------------------------------------------------------------------------------------------

**Known limitations (deferred)**

Two things intentionally not implemented in this PR:

1. **No dropdown for enum-typed properties**. For example, ui5-button's accessibleRole accepts only "Button" or "Link", but the panel renders it as a free-text input rather than a select. Reason: web components ship enum types as TypeScript-only annotations (e.g. accessibleRole: \${ButtonAccessibleRole}` = "Button"`), which are erased at compile time. The runtime metadata contains no enum information, and the framework does not expose enum members on any global. There is no runtime path to recover the valid values. Options considered:

- Ship the @ui5/webcomponents api.json files alongside the extension and read enum members from there — adds hundreds of KB and requires updating per WebC release.
- Ask upstream to expose enum members via a static method on UI5Element — clean fix but out of our scope.

For now the value is still editable as free text; the user just has to know the valid values.

2. **No isDefault flag for WebC properties**. Classic UI5 shows a "(default)" badge next to properties still holding their default value. For WebC we omit this badge because the metadata contains no defaultValue field — defaults are TypeScript class-field initialisers that, when compiled to ES2022 target, land on the instance and cannot be reliably distinguished from user-set values through prototype-chain inspection. A previous heuristic produced misleading results (e.g. selectionMode: "None" shown as non-default). The isDefault field is simply omitted; the DataView already suppresses the badge when the field is absent. A future implementation could snapshot defaults by sampling document.createElement(tag) once per tag at startup.

------------------------------------------------------------------------------------------------------------

**Tested against**

- Pure WebC apps (DynamicPage sample from the webcomponents repo)
- Pure classic UI5 apps (no regression)
- Mixed apps using sap.f.gen.ui5.webcomponents_fiori.dist.* wrapper controls (both trees populate cleanly without duplication, since wrappers keep their web components inside shadow DOM)