### PR TITLE
feat: replace token counter with memory indicator widget

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -164,6 +164,7 @@
         "sinon": true,
         "should": true,
         "Event": true,
+		"KeyboardEvent": true,
 		"ace": true,
 		"self": true,
 		"AbortController": true

--- a/app/scripts/modules/ui/AIChat.js
+++ b/app/scripts/modules/ui/AIChat.js
@@ -2,9 +2,10 @@
 
 const AssistantController = require('../ai/AssistantController.js');
 const AssistantTranscript = require('../ai/AssistantTranscript.js');
+const MemoryIndicator = require('./MemoryIndicator.js');
 
 /**
- * Thin view over the assistant. Owns the banner, input area, confirm dialog, token counter, and
+ * Thin view over the assistant. Owns the banner, input area, confirm dialog, memory indicator, and
  * subscription to {@link AssistantController}. Markdown parsing, JSON / code viewers, scroll
  * bookkeeping, the streaming debounce, and clipboard helpers live in {@link AssistantTranscript}.
  *
@@ -51,7 +52,7 @@ function AIChat(containerId, {
     this._isStreaming = false;
     this._streamingHandle = null;
     this._hasShownUsageWarning = false;
-    // Both the token counter and Clear History button are hidden while no messages exist.
+    // Both the memory indicator and Clear History button are hidden while no messages exist.
     this._hasMessages = false;
 
     this.init();
@@ -61,6 +62,9 @@ AIChat.prototype.init = function () {
     this._render();
     this._transcript = this._transcriptFactory(document.getElementById('ai-messages-container'), {
         onCopyFailed: () => { this._showError('Failed to copy to clipboard'); }
+    });
+    this._memoryIndicator = new MemoryIndicator('ai-memory-indicator', {
+        onClear: () => { this._handleClearHistory(); }
     });
     this._attachEventListeners();
     this._attachControllerListeners();
@@ -100,6 +104,7 @@ AIChat.prototype._render = function () {
                 </div>
                 <div class="ai-error-slot" id="ai-error-slot" role="status" aria-live="polite" hidden></div>
                 <div class="input-wrapper">
+                    <div id="ai-memory-indicator" class="memory-indicator-host"></div>
                     <input
                         type="text"
                         class="ai-input"
@@ -110,9 +115,6 @@ AIChat.prototype._render = function () {
                     <button class="ai-send-button" id="ai-send-button" disabled aria-label="Send message">
                         Send
                     </button>
-                </div>
-                <div class="input-footer">
-                    <span class="token-counter" id="ai-token-counter" role="status" aria-live="polite" hidden></span>
                 </div>
             </div>
 
@@ -230,7 +232,7 @@ AIChat.prototype._attachControllerListeners = function () {
         }
         this._isStreaming = false;
         this._hasMessages = true;
-        this._updateTokenCounter();
+        this._updateMemoryIndicator();
     });
 
     this._controller.on('stream-failed', (err) => {
@@ -247,7 +249,7 @@ AIChat.prototype._attachControllerListeners = function () {
         if (clearButton) {
             clearButton.style.display = 'none';
         }
-        this._updateTokenCounter();
+        this._updateMemoryIndicator();
     });
 
     this._controller.on('inspection-context-cleared', () => {
@@ -258,7 +260,7 @@ AIChat.prototype._attachControllerListeners = function () {
 /**
  * Canonical capability state config. The banner CSS class is `status-<key>` for every key.
  * `skip: true` means no banner update. `showClearButton: true` makes the clear-history button
- * visible. `updateTokens: true` refreshes the token counter. Unknown statuses route to `unavailable`.
+ * visible. `updateMemory: true` refreshes the memory indicator. Unknown statuses route to `unavailable`.
  * @private
  */
 AIChat._CAPABILITY_CONFIG = {
@@ -266,7 +268,7 @@ AIChat._CAPABILITY_CONFIG = {
     'unavailable':      {},
     'downloadable':     {},
     'downloading':      {},
-    'ready':            { showClearButton: true, updateTokens: true },
+    'ready':            { showClearButton: true, updateMemory: true },
     // Recovery: clearConversation destroys the broken session and reseeds.
     'session-failed':   { showClearButton: true },
     // Keep the prior banner; recovery clears on the next successful send. Error surfaces via `_showError`.
@@ -301,8 +303,8 @@ AIChat.prototype._onCapabilityStateChanged = function (state) {
             clearButton.style.display = 'inline-block';
         }
     }
-    if (config.updateTokens) {
-        this._updateTokenCounter();
+    if (config.updateMemory) {
+        this._updateMemoryIndicator();
     }
 };
 
@@ -428,47 +430,63 @@ AIChat.prototype._renderCapabilityBanner = function (status, state) {
     }
 };
 
-AIChat.prototype._updateTokenCounter = function () {
-    const counter = document.getElementById('ai-token-counter');
-    const input = document.getElementById('ai-input');
-    const sendButton = document.getElementById('ai-send-button');
-
-    if (!counter) {
+AIChat.prototype._updateMemoryIndicator = function () {
+    if (!this._memoryIndicator) {
         return;
     }
 
     if (!this._hasMessages) {
-        counter.textContent = '';
-        counter.classList.remove('warning', 'warning-critical', 'quota-exhausted');
-        counter.hidden = true;
+        this._memoryIndicator.update({ hasMessages: false });
+        this._reenableInput();
         return;
     }
 
     this._controller.getUsageInfo().then((usageInfo) => {
+        if (!this._memoryIndicator) {
+            return;
+        }
         if (usageInfo) {
-            counter.textContent = 'Tokens: ' + usageInfo.inputUsage + '/' + usageInfo.inputQuota + ' (' + usageInfo.percentUsed + '%)';
-
-            counter.classList.remove('warning', 'warning-critical', 'quota-exhausted');
+            this._memoryIndicator.update({
+                hasMessages: true,
+                inputUsage: usageInfo.inputUsage,
+                inputQuota: usageInfo.inputQuota,
+                percentUsed: usageInfo.percentUsed
+            });
+            this._checkTokenUsageWarning(usageInfo.percentUsed);
 
             if (usageInfo.percentUsed >= 100) {
-                counter.classList.add('quota-exhausted');
-                input.disabled = true;
-                sendButton.disabled = true;
-                input.placeholder = 'Token quota exhausted. Clear history to continue.';
-            } else if (usageInfo.percentUsed >= 90) {
-                counter.classList.add('warning-critical');
-            } else if (usageInfo.percentUsed >= 70) {
-                counter.classList.add('warning');
+                const input = document.getElementById('ai-input');
+                const sendButton = document.getElementById('ai-send-button');
+                if (input) {
+                    input.disabled = true;
+                    input.placeholder = 'Memory full. Start Fresh to continue.';
+                }
+                if (sendButton) {
+                    sendButton.disabled = true;
+                }
+            } else {
+                this._reenableInput();
             }
-
-            counter.hidden = false;
-            this._checkTokenUsageWarning(usageInfo.percentUsed);
+        } else {
+            // Null usage info is a transient no-data response; re-enable input so a prior
+            // quota-exhausted disable doesn't permanently lock the UI.
+            this._reenableInput();
         }
-        // Null usage: leave the pill's last valid text and state class in place so it does not
-        // flicker off between messages.
-    }, () => {
-        // Rejected usage: same no-op as null.
+    }).catch(() => {
+        // Non-fatal: leave the indicator in its last valid state.
     });
+};
+
+AIChat.prototype._reenableInput = function () {
+    const input = document.getElementById('ai-input');
+    const sendButton = document.getElementById('ai-send-button');
+    if (input) {
+        input.disabled = false;
+        input.placeholder = 'Ask me anything about UI5...';
+    }
+    if (sendButton) {
+        sendButton.disabled = !(input && input.value.trim().length > 0 && !this._isStreaming);
+    }
 };
 
 /**
@@ -479,9 +497,8 @@ AIChat.prototype._checkTokenUsageWarning = function (percentUsed) {
     if (percentUsed >= 70 && !this._hasShownUsageWarning) {
         this._hasShownUsageWarning = true;
 
-        const warningMessage = '💡 Your conversation is getting long (' + percentUsed + '% of token limit used). ' +
-            'For faster responses and better performance, consider clearing the chat history to start fresh. ' +
-            'Click "Clear History" button above.';
+        const warningMessage = 'Your conversation memory is getting full (' + percentUsed + '% used). ' +
+            'Click the memory indicator below and choose "Start Fresh" to free up space.';
 
         this._transcript.appendSystemMessage(warningMessage);
     }
@@ -563,6 +580,10 @@ AIChat.prototype.destroy = function () {
     if (this._transcript && typeof this._transcript.destroy === 'function') {
         this._transcript.destroy();
     }
+    if (this._memoryIndicator && typeof this._memoryIndicator.destroy === 'function') {
+        this._memoryIndicator.destroy();
+    }
+    this._memoryIndicator = null;
 };
 
 module.exports = AIChat;

--- a/app/scripts/modules/ui/MemoryIndicator.js
+++ b/app/scripts/modules/ui/MemoryIndicator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const CIRCLE_RADIUS = 14;
+const CIRCLE_RADIUS = 9;
 const CIRCLE_CIRCUMFERENCE = 2 * Math.PI * CIRCLE_RADIUS;
 
 /**
@@ -27,12 +27,12 @@ function MemoryIndicator(hostId, { onClear = function () {} } = {}) {
 MemoryIndicator.prototype._render = function () {
     this._host.innerHTML = `
         <button class="memory-indicator-btn" aria-label="Conversation memory: 0% used" aria-expanded="false" hidden>
-            <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
-                <circle class="memory-track" cx="16" cy="16" r="${CIRCLE_RADIUS}" />
-                <circle class="memory-fill" cx="16" cy="16" r="${CIRCLE_RADIUS}"
+            <svg width="22" height="22" viewBox="0 0 22 22" aria-hidden="true">
+                <circle class="memory-track" cx="11" cy="11" r="${CIRCLE_RADIUS}" />
+                <circle class="memory-fill" cx="11" cy="11" r="${CIRCLE_RADIUS}"
                     stroke-dasharray="${CIRCLE_CIRCUMFERENCE}"
                     stroke-dashoffset="${CIRCLE_CIRCUMFERENCE}"
-                    transform="rotate(-90 16 16)" />
+                    transform="rotate(-90 11 11)" />
             </svg>
             <span class="memory-pct-label">0%</span>
         </button>

--- a/app/scripts/modules/ui/MemoryIndicator.js
+++ b/app/scripts/modules/ui/MemoryIndicator.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const CIRCLE_RADIUS = 14;
+const CIRCLE_CIRCUMFERENCE = 2 * Math.PI * CIRCLE_RADIUS;
+
+/**
+ * Circular conversation-memory indicator with a popover.
+ *
+ * Replaces the text-based token counter. Renders a circle whose filled arc reflects
+ * context-window usage, with a popover that explains the concept in plain language
+ * and offers a "Start Fresh" action.
+ *
+ * @param {string} hostId - ID of the container element.
+ * @param {Object} options
+ * @param {Function} options.onClear - Called when the user confirms "Start Fresh".
+ * @constructor
+ */
+function MemoryIndicator(hostId, { onClear = function () {} } = {}) {
+    this._host = document.getElementById(hostId);
+    this._onClear = onClear;
+    this._isOpen = false;
+    this._onEscape = null;
+    this._render();
+    this._attachListeners();
+}
+
+MemoryIndicator.prototype._render = function () {
+    this._host.innerHTML = `
+        <button class="memory-indicator-btn" aria-label="Conversation memory: 0% used" aria-expanded="false" hidden>
+            <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
+                <circle class="memory-track" cx="16" cy="16" r="${CIRCLE_RADIUS}" />
+                <circle class="memory-fill" cx="16" cy="16" r="${CIRCLE_RADIUS}"
+                    stroke-dasharray="${CIRCLE_CIRCUMFERENCE}"
+                    stroke-dashoffset="${CIRCLE_CIRCUMFERENCE}"
+                    transform="rotate(-90 16 16)" />
+            </svg>
+            <span class="memory-pct-label">0%</span>
+        </button>
+        <div class="memory-popover" hidden role="region" aria-label="Conversation memory">
+            <div class="memory-popover-header">Conversation Memory</div>
+            <div class="memory-popover-bar-wrap">
+                <div class="memory-popover-bar">
+                    <div class="memory-popover-bar-fill"></div>
+                </div>
+                <span class="memory-popover-pct">0%</span>
+            </div>
+            <div class="memory-popover-detail"></div>
+            <p class="memory-popover-explainer">
+                The AI keeps your conversation in working memory.
+                When it's full, start a new chat to continue.
+                This has nothing to do with payments or subscriptions.
+            </p>
+            <button class="memory-clear-btn">Start Fresh</button>
+        </div>
+    `;
+    this._btn = this._host.querySelector('.memory-indicator-btn');
+    this._fill = this._host.querySelector('.memory-fill');
+    this._pctLabel = this._host.querySelector('.memory-pct-label');
+    this._popover = this._host.querySelector('.memory-popover');
+    this._popoverBar = this._host.querySelector('.memory-popover-bar-fill');
+    this._popoverPct = this._host.querySelector('.memory-popover-pct');
+    this._popoverDetail = this._host.querySelector('.memory-popover-detail');
+    this._clearBtn = this._host.querySelector('.memory-clear-btn');
+};
+
+MemoryIndicator.prototype._attachListeners = function () {
+    this._btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._toggle();
+    });
+    this._popover.addEventListener('click', (e) => {
+        e.stopPropagation();
+    });
+    this._clearBtn.addEventListener('click', () => {
+        this._close();
+        this._onClear();
+    });
+    this._onEscape = (e) => {
+        if (e.key === 'Escape' && this._isOpen) {
+            this._close();
+        }
+    };
+    this._onDocClick = () => {
+        if (this._isOpen) {
+            this._close();
+        }
+    };
+    document.addEventListener('keydown', this._onEscape);
+    document.addEventListener('click', this._onDocClick);
+};
+
+/**
+ * @param {{hasMessages: boolean, inputUsage: number, inputQuota: number, percentUsed: number}} info
+ */
+MemoryIndicator.prototype.update = function (info) {
+    if (!info || !info.hasMessages) {
+        this._btn.hidden = true;
+        this._close();
+        return;
+    }
+
+    const pct = Math.min(100, Math.max(0, info.percentUsed || 0));
+    const offset = CIRCLE_CIRCUMFERENCE * (1 - pct / 100);
+
+    this._fill.style.strokeDashoffset = offset;
+    this._pctLabel.textContent = pct + '%';
+    this._btn.setAttribute('aria-label', 'Conversation memory: ' + pct + '% used');
+
+    this._btn.classList.remove('memory-warning', 'memory-critical', 'memory-exhausted');
+    if (pct >= 100) {
+        this._btn.classList.add('memory-exhausted');
+    } else if (pct >= 90) {
+        this._btn.classList.add('memory-critical');
+    } else if (pct >= 70) {
+        this._btn.classList.add('memory-warning');
+    }
+
+    const usageK = ((info.inputUsage || 0) / 1024).toFixed(1);
+    const quotaK = ((info.inputQuota || 0) / 1024).toFixed(1);
+    this._popoverPct.textContent = pct + '%';
+    this._popoverBar.style.width = pct + '%';
+    this._popoverBar.className = 'memory-popover-bar-fill' +
+        (pct >= 100 ? ' exhausted' : pct >= 90 ? ' critical' : pct >= 70 ? ' warning' : '');
+    this._popoverDetail.textContent = usageK + 'K / ' + quotaK + 'K used';
+
+    this._btn.hidden = false;
+};
+
+MemoryIndicator.prototype._toggle = function () {
+    if (this._isOpen) {
+        this._close();
+    } else {
+        this._open();
+    }
+};
+
+MemoryIndicator.prototype._open = function () {
+    this._isOpen = true;
+    this._popover.hidden = false;
+    this._btn.setAttribute('aria-expanded', 'true');
+};
+
+MemoryIndicator.prototype._close = function () {
+    this._isOpen = false;
+    this._popover.hidden = true;
+    this._btn.setAttribute('aria-expanded', 'false');
+};
+
+MemoryIndicator.prototype.destroy = function () {
+    if (this._onEscape) {
+        document.removeEventListener('keydown', this._onEscape);
+        this._onEscape = null;
+    }
+    if (this._onDocClick) {
+        document.removeEventListener('click', this._onDocClick);
+        this._onDocClick = null;
+    }
+};
+
+module.exports = MemoryIndicator;

--- a/app/styles/less/modules/AIChat.less
+++ b/app/styles/less/modules/AIChat.less
@@ -433,7 +433,14 @@
 .input-wrapper {
     display: flex;
     gap: 8px;
-    align-items: flex-end;
+    align-items: center;
+
+    .memory-indicator-host {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        flex-shrink: 0;
+    }
 }
 
 // Inline error slot: muted red single-line status placed above the input row for transient
@@ -494,41 +501,6 @@
     }
 }
 
-.input-footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 8px;
-    padding: 0 4px;
-}
-
-.token-counter {
-    font-size: 12px;
-    color: @gray-darkest;
-    font-weight: 500;
-    padding: 4px 8px;
-    background-color: fade(@gray, 10%);
-    border-radius: 4px;
-
-    &[hidden] {
-        display: none;
-    }
-
-    &.warning {
-        color: @amber;
-        background-color: fade(@amber, 10%);
-    }
-
-    &.warning-critical {
-        color: @red-saturated;
-        background-color: fade(@red-saturated, 10%);
-    }
-
-    &.quota-exhausted {
-        color: @red-dark;
-        background-color: fade(@red-dark, 10%);
-    }
-}
 
 // Scrollbar styling
 .ai-messages-container {

--- a/app/styles/less/modules/MemoryIndicator.less
+++ b/app/styles/less/modules/MemoryIndicator.less
@@ -1,0 +1,177 @@
+// MemoryIndicator — circular context-window usage widget + popover
+
+.memory-indicator-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 4px;
+    color: @text-color;
+    transition: background-color 0.15s;
+
+    &:hover {
+        background-color: fade(@gray, 12%);
+    }
+
+    &:focus-visible {
+        outline: 2px solid @lighter-blue;
+        outline-offset: 2px;
+    }
+
+    &[hidden] {
+        display: none;
+    }
+
+    // SVG track (background ring)
+    .memory-track {
+        fill: none;
+        stroke: fade(@gray, 25%);
+        stroke-width: 3;
+    }
+
+    // SVG fill arc (usage)
+    .memory-fill {
+        fill: none;
+        stroke: @lighter-blue;
+        stroke-width: 3;
+        stroke-linecap: round;
+        transition: stroke-dashoffset 0.4s ease, stroke 0.3s;
+    }
+
+    .memory-pct-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: @gray-dark;
+        min-width: 26px;
+    }
+
+    // State: warning (70–89%)
+    &.memory-warning {
+        .memory-fill { stroke: @amber; }
+        .memory-pct-label { color: @amber; }
+    }
+
+    // State: critical (90–99%)
+    &.memory-critical {
+        .memory-fill { stroke: @red-saturated; }
+        .memory-pct-label { color: @red-saturated; }
+    }
+
+    // State: exhausted (100%)
+    &.memory-exhausted {
+        .memory-fill { stroke: @red-dark; }
+        .memory-pct-label { color: @red-dark; }
+    }
+}
+
+// Popover — speech bubble anchored above the indicator button, arrow points down to the circle
+.memory-popover {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 0;
+    width: 240px;
+    background: @bg-white;
+    border: 1px solid @border-gray-lighter;
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    padding: 14px 16px 12px;
+    z-index: 100; // Above panel content, below modal dialogs
+
+    // Arrow pointing down toward the circle
+    &::after {
+        content: '';
+        position: absolute;
+        bottom: -6px;
+        left: 14px;
+        width: 10px;
+        height: 10px;
+        background: @bg-white;
+        border-right: 1px solid @border-gray-lighter;
+        border-bottom: 1px solid @border-gray-lighter;
+        transform: rotate(45deg);
+    }
+
+    &[hidden] {
+        display: none;
+    }
+
+    .memory-popover-header {
+        font-size: 13px;
+        font-weight: 600;
+        color: @text-color;
+        margin-bottom: 10px;
+    }
+
+    .memory-popover-bar-wrap {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 4px;
+    }
+
+    .memory-popover-bar {
+        flex: 1;
+        height: 6px;
+        background-color: fade(@gray, 20%);
+        border-radius: 3px;
+        overflow: hidden;
+    }
+
+    .memory-popover-bar-fill {
+        height: 100%;
+        border-radius: 3px;
+        background-color: @lighter-blue;
+        transition: width 0.4s ease;
+
+        &.warning { background-color: @amber; }
+        &.critical { background-color: @red-saturated; }
+        &.exhausted { background-color: @red-dark; }
+    }
+
+    .memory-popover-pct {
+        font-size: 12px;
+        font-weight: 600;
+        color: @text-color;
+        min-width: 32px;
+        text-align: right;
+    }
+
+    .memory-popover-detail {
+        font-size: 11px;
+        color: @gray-dark;
+        margin-bottom: 10px;
+    }
+
+    .memory-popover-explainer {
+        font-size: 12px;
+        color: @gray-dark;
+        line-height: 1.5;
+        margin: 0 0 12px;
+    }
+
+    .memory-clear-btn {
+        width: 100%;
+        padding: 7px 12px;
+        background-color: @lighter-blue;
+        color: @white;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 600;
+        transition: background-color 0.2s;
+
+        &:hover:not(:disabled) {
+            background-color: darken(@lighter-blue, 10%);
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+}

--- a/app/styles/less/themes/base/base.less
+++ b/app/styles/less/themes/base/base.less
@@ -18,4 +18,5 @@
 @import "../../modules/DataGrid.less";
 @import "../../modules/ElementsRegistry.less";
 @import "../../modules/AIChat.less";
+@import "../../modules/MemoryIndicator.less";
 

--- a/tests/modules/ui/AIChat.spec.js
+++ b/tests/modules/ui/AIChat.spec.js
@@ -499,18 +499,22 @@ describe('AIChat', function () {
         });
     });
 
-    describe('Token counter', function () {
-        it('should leave the token counter empty when the controller reports no usage info, so a non-ready or quota-unaware session does not paint stale numbers', function () {
+    describe('Memory indicator', function () {
+        it('should not call the memory indicator with usage data when the controller reports no usage info, so a non-ready session does not paint stale numbers', function () {
+            let updateArgs = null;
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { updateArgs = info; orig(info); };
+
+            // getUsageInfo resolves to null by default in fakeController
             fakeController.fire('capability-state-changed', {
                 status: 'ready', message: 'ready', progress: 0
             });
 
-            // getUsageInfo resolves to null; drain the microtask.
             return Promise.resolve().then(function () {
                 return Promise.resolve();
             }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.textContent.should.equal('');
+                updateArgs.should.not.equal(null);
+                updateArgs.hasMessages.should.be.false;
             });
         });
 
@@ -536,34 +540,36 @@ describe('AIChat', function () {
 
             return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
                 const warnings = fakeTranscript.calls.filter(function (c) {
-                    return c.type === 'appendSystemMessage' && c.message.indexOf('token limit') !== -1;
+                    return c.type === 'appendSystemMessage' && c.message.indexOf('conversation memory') !== -1;
                 });
                 warnings.length.should.equal(1);
             });
         });
     });
 
-    describe('Empty-conversation gating for token counter and Clear History button', function () {
-        it('should render the token counter with the semantic hidden attribute on a fresh load, so the pill is absent from the input footer until there is a message to account for', function () {
-            const counter = document.getElementById('ai-token-counter');
-            counter.hasAttribute('hidden').should.be.true;
+    describe('Empty-conversation gating for memory indicator and Clear History button', function () {
+        it('should hide the memory indicator on a fresh load before any messages exist', function () {
+            const host = document.getElementById('ai-memory-indicator');
+            host.should.exist;
+            const btn = host.querySelector('.memory-indicator-btn');
+            btn.hasAttribute('hidden').should.be.true;
         });
 
-        it('should preserve the token counter\'s role and aria-live attributes so screen-reader announcement behaviour is not regressed by the hide gate', function () {
-            const counter = document.getElementById('ai-token-counter');
-            counter.getAttribute('role').should.equal('status');
-            counter.getAttribute('aria-live').should.equal('polite');
+        it('should render the memory indicator host with an accessible button so screen-reader users can identify the widget', function () {
+            const btn = document.querySelector('.memory-indicator-btn');
+            btn.should.exist;
+            btn.getAttribute('aria-label').should.be.a('string');
+            btn.getAttribute('aria-label').length.should.be.above(0);
         });
 
-        it('should keep the token counter hidden after a ready capability state with null usage info in an empty conversation, so a pristine panel does not paint an empty pill', function () {
+        it('should keep the memory indicator hidden after a ready capability state with null usage info in an empty conversation', function () {
             fakeController.fire('capability-state-changed', {
                 status: 'ready', message: 'ready', progress: 0
             });
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.hasAttribute('hidden').should.be.true;
-                counter.textContent.should.equal('');
+                const btn = document.querySelector('.memory-indicator-btn');
+                btn.hasAttribute('hidden').should.be.true;
             });
         });
 
@@ -579,39 +585,48 @@ describe('AIChat', function () {
             clearButton.style.display.should.not.equal('none');
         });
 
-        it('should reveal the token counter after the assistant stream completes for the first user turn, so the developer sees usage numbers alongside the first response', function () {
+        it('should reveal the memory indicator after the assistant stream completes for the first user turn', function () {
             fakeController.getUsageInfo = function () {
                 return Promise.resolve({inputUsage: 100, inputQuota: 1000, percentUsed: 10});
             };
+
+            let updateArgs = null;
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { updateArgs = info; orig(info); };
 
             const input = document.getElementById('ai-input');
             input.value = 'hi';
             input.dispatchEvent(new Event('input'));
             document.getElementById('ai-send-button').click();
-
             fakeController.fire('stream-complete', {content: 'hello'});
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.hasAttribute('hidden').should.be.false;
-                counter.textContent.should.contain('100');
+                updateArgs.should.exist;
+                updateArgs.hasMessages.should.be.true;
+                updateArgs.inputUsage.should.equal(100);
             });
         });
 
-        it('should hide the token counter and the Clear History button on conversation-cleared, so the post-clear state matches the fresh-load state', function () {
+        it('should hide the memory indicator and the Clear History button on conversation-cleared', function () {
             // Seed a non-empty conversation with visible pill and clear button.
             fakeController.getUsageInfo = function () {
                 return Promise.resolve({inputUsage: 100, inputQuota: 1000, percentUsed: 10});
             };
+
+            let lastUpdateArgs = null;
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { lastUpdateArgs = info; orig(info); };
+
             fakeController.fire('conversation-loaded', [{role: 'user', content: 'hi'}]);
             fakeController.fire('capability-state-changed', {
                 status: 'ready', message: 'ready', progress: 0
             });
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
+                lastUpdateArgs.should.exist;
+                lastUpdateArgs.hasMessages.should.be.true;
+
                 const clearButton = document.getElementById('ai-clear-history-button');
-                counter.hasAttribute('hidden').should.be.false;
                 clearButton.style.display.should.not.equal('none');
 
                 // Now clear. Post-clear a capability-state ready may still arrive due to reseed;
@@ -623,18 +638,20 @@ describe('AIChat', function () {
 
                 return new Promise(function (resolve) { setTimeout(resolve, 10); });
             }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
+                lastUpdateArgs.hasMessages.should.be.false;
                 const clearButton = document.getElementById('ai-clear-history-button');
-                counter.hasAttribute('hidden').should.be.true;
-                counter.textContent.should.equal('');
                 clearButton.style.display.should.equal('none');
             });
         });
 
-        it('should reveal the token counter and Clear History button again when a new message is sent after a clear, so the panel recovers to the active-conversation state', function () {
+        it('should reveal the memory indicator and Clear History button again when a new message is sent after a clear', function () {
             fakeController.getUsageInfo = function () {
                 return Promise.resolve({inputUsage: 50, inputQuota: 1000, percentUsed: 5});
             };
+
+            let lastUpdateArgs = null;
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { lastUpdateArgs = info; orig(info); };
 
             fakeController.fire('conversation-cleared');
 
@@ -650,17 +667,21 @@ describe('AIChat', function () {
             });
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
+                lastUpdateArgs.should.exist;
+                lastUpdateArgs.hasMessages.should.be.true;
                 const clearButton = document.getElementById('ai-clear-history-button');
-                counter.hasAttribute('hidden').should.be.false;
                 clearButton.style.display.should.not.equal('none');
             });
         });
 
-        it('should reveal the token counter once usage info resolves for a restored non-empty conversation, so a warm start shows the same widgets as a live session', function () {
+        it('should reveal the memory indicator once usage info resolves for a restored non-empty conversation', function () {
             fakeController.getUsageInfo = function () {
                 return Promise.resolve({inputUsage: 200, inputQuota: 1000, percentUsed: 20});
             };
+
+            let updateArgs = null;
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { updateArgs = info; orig(info); };
 
             fakeController.fire('conversation-loaded', [
                 {role: 'user', content: 'q'},
@@ -671,27 +692,31 @@ describe('AIChat', function () {
             });
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.hasAttribute('hidden').should.be.false;
-                counter.textContent.should.contain('200');
+                updateArgs.should.exist;
+                updateArgs.hasMessages.should.be.true;
+                updateArgs.inputUsage.should.equal(200);
             });
         });
 
-        it('should leave the token counter and Clear History button hidden when a restored conversation is empty, so warm-starting an empty store looks identical to a fresh load', function () {
+        it('should leave the memory indicator and Clear History button hidden when a restored conversation is empty', function () {
             fakeController.fire('conversation-loaded', []);
             fakeController.fire('capability-state-changed', {
                 status: 'ready', message: 'ready', progress: 0
             });
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
+                const btn = document.querySelector('.memory-indicator-btn');
+                btn.hasAttribute('hidden').should.be.true;
                 const clearButton = document.getElementById('ai-clear-history-button');
-                counter.hasAttribute('hidden').should.be.true;
                 clearButton.style.display.should.equal('none');
             });
         });
 
-        it('should not flicker the token counter off mid-stream when a usage-info refresh briefly returns null, so the last valid pill stays visible until the next successful update', function () {
+        it('should not call the memory indicator with hasMessages false when a usage-info refresh briefly returns null mid-conversation', function () {
+            let updateCalls = [];
+            const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+            aiChat._memoryIndicator.update = function (info) { updateCalls.push(info); orig(info); };
+
             let usageQueue = [
                 {inputUsage: 100, inputQuota: 1000, percentUsed: 10},
                 null
@@ -707,26 +732,25 @@ describe('AIChat', function () {
             fakeController.fire('stream-complete', {content: 'a'});
 
             return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.hasAttribute('hidden').should.be.false;
-                counter.textContent.should.contain('100');
+                // First update: should have hasMessages true
+                updateCalls.filter(function (c) { return c.hasMessages === true; }).length.should.be.above(0);
 
-                // Second refresh: usage briefly null (stale/unavailable). Pill must not flicker off.
+                // Second refresh: usage briefly null — _updateMemoryIndicator should not call update with hasMessages false
                 fakeController.fire('capability-state-changed', {
                     status: 'ready', message: 'ready', progress: 0
                 });
 
                 return new Promise(function (resolve) { setTimeout(resolve, 10); });
             }).then(function () {
-                const counter = document.getElementById('ai-token-counter');
-                counter.hasAttribute('hidden').should.be.false;
-                counter.textContent.should.contain('100');
+                const falseCalls = updateCalls.filter(function (c) { return c.hasMessages === false; });
+                falseCalls.length.should.equal(0);
             });
         });
     });
 
     describe('Inline error slot', function () {
         it('should render an inline error slot inside the input area, hidden by default with role=status and aria-live=polite, so screen readers announce errors non-interruptively when they appear', function () {
+
             const slot = document.getElementById('ai-error-slot');
             slot.should.exist;
             slot.getAttribute('role').should.equal('status');
@@ -827,5 +851,216 @@ describe('AIChat', function () {
             slot.textContent.should.contain('second');
             slot.textContent.should.not.contain('first');
         });
+    });
+});
+
+describe('MemoryIndicator integration', function () {
+    const fixtures = document.getElementById('fixtures');
+    let aiChat;
+    let fakeController;
+
+    beforeEach(function () {
+        fixtures.innerHTML = '<div id="ai-chat"></div>';
+        fakeController = createFakeController();
+        const fakeTranscript = createFakeTranscript();
+        aiChat = new AIChat('ai-chat', {
+            getAppInfo: function () { return null; },
+            controller: fakeController,
+            transcriptFactory: function (host, options) {
+                if (options && typeof options.onCopyFailed === 'function') {
+                    fakeTranscript.onCopyFailed = options.onCopyFailed;
+                }
+                return fakeTranscript;
+            }
+        });
+    });
+
+    afterEach(function () {
+        aiChat = null;
+        fakeController = null;
+        fixtures.innerHTML = '';
+    });
+
+    it('should render the memory indicator host div inside the input footer', function () {
+        const host = document.getElementById('ai-memory-indicator');
+        host.should.exist;
+    });
+
+    it('should call update on the indicator after stream-complete with usage data', function (done) {
+        let updateArgs = null;
+        const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+        aiChat._memoryIndicator.update = function (info) {
+            updateArgs = info;
+            orig(info);
+        };
+
+        fakeController.getUsageInfo = function () {
+            return Promise.resolve({ inputUsage: 1000, inputQuota: 6144, percentUsed: 16 });
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        setTimeout(function () {
+            updateArgs.should.exist;
+            updateArgs.percentUsed.should.equal(16);
+            done();
+        }, 50);
+    });
+
+    it('should call update with hasMessages false after conversation-cleared', function (done) {
+        let updateArgs = null;
+        const orig = aiChat._memoryIndicator.update.bind(aiChat._memoryIndicator);
+        aiChat._memoryIndicator.update = function (info) {
+            updateArgs = info;
+            orig(info);
+        };
+
+        fakeController.fire('conversation-cleared');
+
+        setTimeout(function () {
+            updateArgs.should.exist;
+            updateArgs.hasMessages.should.be.false;
+            done();
+        }, 50);
+    });
+
+    it('should re-enable the input and restore its placeholder after conversation-cleared when the input was disabled due to quota exhaustion', function (done) {
+        fakeController.getUsageInfo = function () {
+            return Promise.resolve({ inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        setTimeout(function () {
+            input.disabled.should.be.true;
+
+            fakeController.fire('conversation-cleared');
+
+            setTimeout(function () {
+                input.disabled.should.be.false;
+                input.placeholder.should.not.contain('full');
+                done();
+            }, 50);
+        }, 50);
+    });
+
+    it('should not call memoryIndicator.update after destroy is called while a getUsageInfo promise is in flight', function (done) {
+        var resolveFn;
+        fakeController.getUsageInfo = function () {
+            return new Promise(function (resolve) { resolveFn = resolve; });
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        var updateCalledAfterDestroy = false;
+        var indicator = aiChat._memoryIndicator;
+        var origUpdate = indicator.update.bind(indicator);
+        indicator.update = function (info) {
+            updateCalledAfterDestroy = true;
+            origUpdate(info);
+        };
+
+        aiChat.destroy();
+        aiChat = null;
+
+        resolveFn({ inputUsage: 100, inputQuota: 1000, percentUsed: 10 });
+
+        setTimeout(function () {
+            updateCalledAfterDestroy.should.be.false;
+            done();
+        }, 20);
+    });
+
+    it('should re-enable the input when percentUsed drops below 100 on a subsequent update with messages present', function (done) {
+        var callCount = 0;
+        fakeController.getUsageInfo = function () {
+            callCount++;
+            if (callCount === 1) {
+                return Promise.resolve({ inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+            }
+            return Promise.resolve({ inputUsage: 100, inputQuota: 6144, percentUsed: 2 });
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        setTimeout(function () {
+            input.disabled.should.be.true;
+
+            fakeController.fire('capability-state-changed', { status: 'ready', message: 'ready', progress: 0 });
+
+            setTimeout(function () {
+                input.disabled.should.be.false;
+                done();
+            }, 50);
+        }, 50);
+    });
+
+    it('should not re-enable the send button if the input field is empty after clearing a quota-exhausted conversation', function (done) {
+        fakeController.getUsageInfo = function () {
+            return Promise.resolve({ inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        setTimeout(function () {
+            input.disabled.should.be.true;
+
+            input.value = '';
+            fakeController.fire('conversation-cleared');
+
+            setTimeout(function () {
+                const sendButton = document.getElementById('ai-send-button');
+                sendButton.disabled.should.be.true;
+                done();
+            }, 50);
+        }, 50);
+    });
+
+    it('should re-enable the input when a null usageInfo response follows a quota-exhausted state, so a transient null does not permanently lock the UI', function (done) {
+        var callCount = 0;
+        fakeController.getUsageInfo = function () {
+            callCount++;
+            if (callCount === 1) {
+                return Promise.resolve({ inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+            }
+            return Promise.resolve(null);
+        };
+
+        const input = document.getElementById('ai-input');
+        input.value = 'hi';
+        input.dispatchEvent(new Event('input'));
+        document.getElementById('ai-send-button').click();
+        fakeController.fire('stream-complete', { content: 'response' });
+
+        setTimeout(function () {
+            input.disabled.should.be.true;
+
+            fakeController.fire('capability-state-changed', { status: 'ready', message: 'ready', progress: 0 });
+
+            setTimeout(function () {
+                input.disabled.should.be.false;
+                done();
+            }, 50);
+        }, 50);
     });
 });

--- a/tests/modules/ui/MemoryIndicator.spec.js
+++ b/tests/modules/ui/MemoryIndicator.spec.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const MemoryIndicator = require('../../../app/scripts/modules/ui/MemoryIndicator.js');
+
+describe('MemoryIndicator', function () {
+    const fixtures = document.getElementById('fixtures');
+    let indicator;
+
+    beforeEach(function () {
+        fixtures.innerHTML = '<div id="memory-host"></div>';
+        indicator = new MemoryIndicator('memory-host', { onClear: function () {} });
+    });
+
+    afterEach(function () {
+        indicator.destroy();
+        fixtures.innerHTML = '';
+        indicator = null;
+    });
+
+    describe('Constructor & render', function () {
+        it('should render a circle button inside the host', function () {
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.should.exist;
+        });
+
+        it('should render the popover element inside the host, hidden by default', function () {
+            const popover = fixtures.querySelector('.memory-popover');
+            popover.should.exist;
+            popover.hidden.should.be.true;
+        });
+
+        it('should render the circle as an SVG', function () {
+            const svg = fixtures.querySelector('.memory-indicator-btn svg');
+            svg.should.exist;
+        });
+    });
+
+    describe('#update()', function () {
+        it('should hide the indicator when hasMessages is false', function () {
+            indicator.update({ hasMessages: false, inputUsage: 0, inputQuota: 6144, percentUsed: 0 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.hidden.should.be.true;
+        });
+
+        it('should show the indicator when hasMessages is true', function () {
+            indicator.update({ hasMessages: true, inputUsage: 100, inputQuota: 6144, percentUsed: 2 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.hidden.should.be.false;
+        });
+
+        it('should update the aria-label with the percentage', function () {
+            indicator.update({ hasMessages: true, inputUsage: 3000, inputQuota: 6144, percentUsed: 49 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.getAttribute('aria-label').should.contain('49%');
+        });
+
+        it('should add warning class at 70%', function () {
+            indicator.update({ hasMessages: true, inputUsage: 4500, inputQuota: 6144, percentUsed: 73 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.classList.contains('memory-warning').should.be.true;
+        });
+
+        it('should add critical class at 90%', function () {
+            indicator.update({ hasMessages: true, inputUsage: 5700, inputQuota: 6144, percentUsed: 93 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.classList.contains('memory-critical').should.be.true;
+        });
+
+        it('should add exhausted class at 100%', function () {
+            indicator.update({ hasMessages: true, inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.classList.contains('memory-exhausted').should.be.true;
+        });
+
+        it('should remove stale state classes when usage drops below threshold', function () {
+            indicator.update({ hasMessages: true, inputUsage: 6144, inputQuota: 6144, percentUsed: 100 });
+            indicator.update({ hasMessages: true, inputUsage: 100, inputQuota: 6144, percentUsed: 2 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.classList.contains('memory-exhausted').should.be.false;
+            btn.classList.contains('memory-critical').should.be.false;
+            btn.classList.contains('memory-warning').should.be.false;
+        });
+    });
+
+    describe('Popover open / close', function () {
+        beforeEach(function () {
+            indicator.update({ hasMessages: true, inputUsage: 1000, inputQuota: 6144, percentUsed: 16 });
+        });
+
+        it('should open the popover when the circle button is clicked', function () {
+            fixtures.querySelector('.memory-indicator-btn').click();
+            fixtures.querySelector('.memory-popover').hidden.should.be.false;
+        });
+
+        it('should close the popover when the circle button is clicked again', function () {
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.click();
+            btn.click();
+            fixtures.querySelector('.memory-popover').hidden.should.be.true;
+        });
+
+        it('should close the popover on Escape keydown', function () {
+            fixtures.querySelector('.memory-indicator-btn').click();
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            fixtures.querySelector('.memory-popover').hidden.should.be.true;
+        });
+
+        it('should show usage text in the popover', function () {
+            fixtures.querySelector('.memory-indicator-btn').click();
+            const popover = fixtures.querySelector('.memory-popover');
+            popover.textContent.should.contain('16%');
+        });
+
+        it('should show plain-language explanation in the popover', function () {
+            fixtures.querySelector('.memory-indicator-btn').click();
+            const popover = fixtures.querySelector('.memory-popover');
+            popover.textContent.should.contain('memory');
+        });
+
+        it('should render a Start Fresh button in the popover', function () {
+            fixtures.querySelector('.memory-indicator-btn').click();
+            const btn = fixtures.querySelector('.memory-popover .memory-clear-btn');
+            btn.should.exist;
+        });
+    });
+
+    describe('onClear callback', function () {
+        it('should call onClear when Start Fresh is clicked', function () {
+            let called = false;
+            indicator.destroy();
+            fixtures.innerHTML = '<div id="memory-host2"></div>';
+            indicator = new MemoryIndicator('memory-host2', { onClear: function () { called = true; } });
+            indicator.update({ hasMessages: true, inputUsage: 1000, inputQuota: 6144, percentUsed: 16 });
+            fixtures.querySelector('.memory-indicator-btn').click();
+            fixtures.querySelector('.memory-clear-btn').click();
+            called.should.be.true;
+        });
+    });
+
+    describe('aria-expanded', function () {
+        it('should have aria-expanded="false" on the button initially', function () {
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.getAttribute('aria-expanded').should.equal('false');
+        });
+
+        it('should set aria-expanded="true" when the popover is opened', function () {
+            indicator.update({ hasMessages: true, inputUsage: 1000, inputQuota: 6144, percentUsed: 16 });
+            fixtures.querySelector('.memory-indicator-btn').click();
+            fixtures.querySelector('.memory-indicator-btn').getAttribute('aria-expanded').should.equal('true');
+        });
+
+        it('should set aria-expanded="false" when the popover is closed', function () {
+            indicator.update({ hasMessages: true, inputUsage: 1000, inputQuota: 6144, percentUsed: 16 });
+            const btn = fixtures.querySelector('.memory-indicator-btn');
+            btn.click();
+            btn.click();
+            btn.getAttribute('aria-expanded').should.equal('false');
+        });
+    });
+
+    describe('popover role', function () {
+        it('should use role="region" on the popover, not role="dialog"', function () {
+            const popover = fixtures.querySelector('.memory-popover');
+            popover.getAttribute('role').should.equal('region');
+            popover.getAttribute('role').should.not.equal('dialog');
+        });
+    });
+
+    describe('#destroy()', function () {
+        it('should remove the Escape keydown listener so it does not fire after destroy', function () {
+            indicator.update({ hasMessages: true, inputUsage: 100, inputQuota: 6144, percentUsed: 2 });
+            fixtures.querySelector('.memory-indicator-btn').click(); // open it
+            indicator.destroy();
+            // Manually spy on _close — if the listener were still active it would call _close
+            let closeCalled = false;
+            const orig = indicator._close.bind(indicator);
+            indicator._close = function () { closeCalled = true; orig(); };
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            closeCalled.should.be.false;
+        });
+    });
+});

--- a/tests/styles/themes/dark/dark.css
+++ b/tests/styles/themes/dark/dark.css
@@ -1633,7 +1633,13 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .input-wrapper {
   display: flex;
   gap: 8px;
-  align-items: flex-end;
+  align-items: center;
+}
+.input-wrapper .memory-indicator-host {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 .ai-error-slot {
   color: #22D4C2;
@@ -1681,36 +1687,6 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .ai-send-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-.input-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 8px;
-  padding: 0 4px;
-}
-.token-counter {
-  font-size: 12px;
-  color: #949494;
-  font-weight: 500;
-  padding: 4px 8px;
-  background-color: rgba(98, 98, 98, 0.1);
-  border-radius: 4px;
-}
-.token-counter[hidden] {
-  display: none;
-}
-.token-counter.warning {
-  color: #FBBF24;
-  background-color: rgba(251, 191, 36, 0.1);
-}
-.token-counter.warning-critical {
-  color: #22D4C2;
-  background-color: rgba(34, 212, 194, 0.1);
-}
-.token-counter.quota-exhausted {
-  color: #DC2626;
-  background-color: rgba(220, 38, 38, 0.1);
 }
 .ai-messages-container::-webkit-scrollbar {
   width: 8px;
@@ -1999,6 +1975,163 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
   100% {
     content: '...';
   }
+}
+.memory-indicator-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  color: #949494;
+  transition: background-color 0.15s;
+}
+.memory-indicator-btn:hover {
+  background-color: rgba(98, 98, 98, 0.12);
+}
+.memory-indicator-btn:focus-visible {
+  outline: 2px solid #C98730;
+  outline-offset: 2px;
+}
+.memory-indicator-btn[hidden] {
+  display: none;
+}
+.memory-indicator-btn .memory-track {
+  fill: none;
+  stroke: rgba(98, 98, 98, 0.25);
+  stroke-width: 3;
+}
+.memory-indicator-btn .memory-fill {
+  fill: none;
+  stroke: #C98730;
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease, stroke 0.3s;
+}
+.memory-indicator-btn .memory-pct-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a3a3a3;
+  min-width: 26px;
+}
+.memory-indicator-btn.memory-warning .memory-fill {
+  stroke: #FBBF24;
+}
+.memory-indicator-btn.memory-warning .memory-pct-label {
+  color: #FBBF24;
+}
+.memory-indicator-btn.memory-critical .memory-fill {
+  stroke: #22D4C2;
+}
+.memory-indicator-btn.memory-critical .memory-pct-label {
+  color: #22D4C2;
+}
+.memory-indicator-btn.memory-exhausted .memory-fill {
+  stroke: #DC2626;
+}
+.memory-indicator-btn.memory-exhausted .memory-pct-label {
+  color: #DC2626;
+}
+.memory-popover {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 0;
+  width: 240px;
+  background: #252525;
+  border: 1px solid #d4d4d4;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  padding: 14px 16px 12px;
+  z-index: 100;
+}
+.memory-popover::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 14px;
+  width: 10px;
+  height: 10px;
+  background: #252525;
+  border-right: 1px solid #d4d4d4;
+  border-bottom: 1px solid #d4d4d4;
+  transform: rotate(45deg);
+}
+.memory-popover[hidden] {
+  display: none;
+}
+.memory-popover .memory-popover-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: #949494;
+  margin-bottom: 10px;
+}
+.memory-popover .memory-popover-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.memory-popover .memory-popover-bar {
+  flex: 1;
+  height: 6px;
+  background-color: rgba(98, 98, 98, 0.2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.memory-popover .memory-popover-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background-color: #C98730;
+  transition: width 0.4s ease;
+}
+.memory-popover .memory-popover-bar-fill.warning {
+  background-color: #FBBF24;
+}
+.memory-popover .memory-popover-bar-fill.critical {
+  background-color: #22D4C2;
+}
+.memory-popover .memory-popover-bar-fill.exhausted {
+  background-color: #DC2626;
+}
+.memory-popover .memory-popover-pct {
+  font-size: 12px;
+  font-weight: 600;
+  color: #949494;
+  min-width: 32px;
+  text-align: right;
+}
+.memory-popover .memory-popover-detail {
+  font-size: 11px;
+  color: #a3a3a3;
+  margin-bottom: 10px;
+}
+.memory-popover .memory-popover-explainer {
+  font-size: 12px;
+  color: #a3a3a3;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+.memory-popover .memory-clear-btn {
+  width: 100%;
+  padding: 7px 12px;
+  background-color: #C98730;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background-color 0.2s;
+}
+.memory-popover .memory-clear-btn:hover:not(:disabled) {
+  background-color: #a06b26;
+}
+.memory-popover .memory-clear-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .ai-message.message-assistant .message-content {
   color: #fff;

--- a/tests/styles/themes/light/light.css
+++ b/tests/styles/themes/light/light.css
@@ -1633,7 +1633,13 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .input-wrapper {
   display: flex;
   gap: 8px;
-  align-items: flex-end;
+  align-items: center;
+}
+.input-wrapper .memory-indicator-host {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 .ai-error-slot {
   color: #C80000;
@@ -1681,36 +1687,6 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .ai-send-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-.input-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 8px;
-  padding: 0 4px;
-}
-.token-counter {
-  font-size: 12px;
-  color: #222;
-  font-weight: 500;
-  padding: 4px 8px;
-  background-color: rgba(187, 187, 187, 0.1);
-  border-radius: 4px;
-}
-.token-counter[hidden] {
-  display: none;
-}
-.token-counter.warning {
-  color: #B45309;
-  background-color: rgba(180, 83, 9, 0.1);
-}
-.token-counter.warning-critical {
-  color: #C80000;
-  background-color: rgba(200, 0, 0, 0.1);
-}
-.token-counter.quota-exhausted {
-  color: #7F1D1D;
-  background-color: rgba(127, 29, 29, 0.1);
 }
 .ai-messages-container::-webkit-scrollbar {
   width: 8px;
@@ -1999,6 +1975,163 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
   100% {
     content: '...';
   }
+}
+.memory-indicator-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  color: #222;
+  transition: background-color 0.15s;
+}
+.memory-indicator-btn:hover {
+  background-color: rgba(187, 187, 187, 0.12);
+}
+.memory-indicator-btn:focus-visible {
+  outline: 2px solid #3879D9;
+  outline-offset: 2px;
+}
+.memory-indicator-btn[hidden] {
+  display: none;
+}
+.memory-indicator-btn .memory-track {
+  fill: none;
+  stroke: rgba(187, 187, 187, 0.25);
+  stroke-width: 3;
+}
+.memory-indicator-btn .memory-fill {
+  fill: none;
+  stroke: #3879D9;
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease, stroke 0.3s;
+}
+.memory-indicator-btn .memory-pct-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a3a3a3;
+  min-width: 26px;
+}
+.memory-indicator-btn.memory-warning .memory-fill {
+  stroke: #B45309;
+}
+.memory-indicator-btn.memory-warning .memory-pct-label {
+  color: #B45309;
+}
+.memory-indicator-btn.memory-critical .memory-fill {
+  stroke: #C80000;
+}
+.memory-indicator-btn.memory-critical .memory-pct-label {
+  color: #C80000;
+}
+.memory-indicator-btn.memory-exhausted .memory-fill {
+  stroke: #7F1D1D;
+}
+.memory-indicator-btn.memory-exhausted .memory-pct-label {
+  color: #7F1D1D;
+}
+.memory-popover {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 0;
+  width: 240px;
+  background: #fff;
+  border: 1px solid #d4d4d4;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  padding: 14px 16px 12px;
+  z-index: 100;
+}
+.memory-popover::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 14px;
+  width: 10px;
+  height: 10px;
+  background: #fff;
+  border-right: 1px solid #d4d4d4;
+  border-bottom: 1px solid #d4d4d4;
+  transform: rotate(45deg);
+}
+.memory-popover[hidden] {
+  display: none;
+}
+.memory-popover .memory-popover-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 10px;
+}
+.memory-popover .memory-popover-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.memory-popover .memory-popover-bar {
+  flex: 1;
+  height: 6px;
+  background-color: rgba(187, 187, 187, 0.2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.memory-popover .memory-popover-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background-color: #3879D9;
+  transition: width 0.4s ease;
+}
+.memory-popover .memory-popover-bar-fill.warning {
+  background-color: #B45309;
+}
+.memory-popover .memory-popover-bar-fill.critical {
+  background-color: #C80000;
+}
+.memory-popover .memory-popover-bar-fill.exhausted {
+  background-color: #7F1D1D;
+}
+.memory-popover .memory-popover-pct {
+  font-size: 12px;
+  font-weight: 600;
+  color: #222;
+  min-width: 32px;
+  text-align: right;
+}
+.memory-popover .memory-popover-detail {
+  font-size: 11px;
+  color: #a3a3a3;
+  margin-bottom: 10px;
+}
+.memory-popover .memory-popover-explainer {
+  font-size: 12px;
+  color: #a3a3a3;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+.memory-popover .memory-clear-btn {
+  width: 100%;
+  padding: 7px 12px;
+  background-color: #3879D9;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background-color 0.2s;
+}
+.memory-popover .memory-clear-btn:hover:not(:disabled) {
+  background-color: #2460ba;
+}
+.memory-popover .memory-clear-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .ai-message.message-assistant .message-content {
   color: #222 !important;


### PR DESCRIPTION
Replaces the static token-counter pill in the input footer with a
`MemoryIndicator` component — a circular arc gauge with a percentage
label that opens a popover on click. The popover shows a progress bar,
token detail, a brief explainer, and a "Start Fresh" button wired to
`clearHistory`.

- Adds `MemoryIndicator.js` and `MemoryIndicator.less` (new component)
- Removes `.input-footer` / `.token-counter` styles; introduces
  `.memory-indicator-host`, `.memory-indicator-btn`, `.memory-popover`
- `AIChat` now owns a `_memoryIndicator` instance; `_updateTokenCounter`
  becomes `_updateMemoryIndicator`, delegating all rendering to the widget
- Adds `_reenableInput()` helper so quota-exhausted disable is always
  paired with a clean re-enable path (clear, null usage, or sub-100%)
- Updates warning copy to reference "conversation memory" instead of
  "token limit"
- Extends `AIChat.spec.js` and adds `MemoryIndicator.spec.js` / integration
  suite covering hide/show gating, quota exhaustion, destroy-race guard,
  and null-usage re-enable
  
  JIRA: BGSOFUIPIRIN-7101