### PR TITLE
feat(flexibility-registry): add Flexibility Registry tab with change export

### DIFF
--- a/app/html/panel/ui5/index.html
+++ b/app/html/panel/ui5/index.html
@@ -17,6 +17,7 @@
                 <tab id="app-info-tab">Application Information</tab>
                 <tab id="odata-tab">OData Requests</tab>
                 <tab id="elements-registry-tab">Elements Registry</tab>
+                <tab id="flexibility-registry-tab">Flexibility Registry</tab>
                 <tab id="ai-tab">AI Assistant</tab>
             </tabs>
             <contents>
@@ -157,6 +158,24 @@
                     </splitter>
                 </content>
                 <!-- Elements registry /ends-->
+
+                <!-- Flexibility /start-->
+                <content for="flexibility-registry-tab" class="flexibilityTab">
+                    <splitter id="flexibility-horizontal-splitter">
+                        <!-- SplitContainer begin side /start-->
+                        <start>
+                            <flexibility-master-view id="flexibility-tab-master"/>
+                        </start>
+                        <!-- SplitContainer begin side /ends-->
+
+                        <!-- SplitContainer end side /start-->
+                        <end>
+                            <flexibility-detail-view id="flexibility-tab-detail"/>
+                        </end>
+                        <!-- SplitContainer end side /ends-->
+                    </splitter>
+                </content>
+                <!-- Flexibility /ends-->
 
                 <!-- AI Chat /start-->
                 <content for="ai-tab">

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -1,4 +1,5 @@
 
+// jshint maxstatements:70
 (function () {
     'use strict';
 
@@ -23,8 +24,9 @@
     var XMLDetailView = require('../../../modules/ui/XMLDetailView.js');
     var ControllerDetailView = require('../../../modules/ui/ControllerDetailView.js');
     var OElementsRegistryMasterView = require('../../../modules/ui/OElementsRegistryMasterView.js');
+    var FlexibilityRegistryDetailView = require('../../../modules/ui/FlexibilityRegistryDetailView.js');
+    var FlexibilityRegistryMasterView = require('../../../modules/ui/FlexibilityRegistryMasterView.js');
     var AIChat = require('../../../modules/ui/AIChat.js');
-
 
     // Apply theme
     // ================================================================================
@@ -53,6 +55,10 @@
     var framesSelect;
     var displayFrameData;
     var updateSupportabilityOverlay;
+    var oFlexibilityHorizontalSplitter;
+    var oFlexibilityDetailView;
+    var oFlexibilityRegistryMasterView;
+
     // Synthetic root inserted under the merged tree (mixed pages) to group all
     // WebC controls under one expandable header. Its id ('__webc_root__') is
     // reserved: selecting or hovering it in the tree must be a no-op since it
@@ -438,6 +444,7 @@
             UI5Data.selectedElementId && controlTree.setSelectedElement(UI5Data.selectedElementId);
             appInfo.setData(UI5Data.applicationInformation);
             UI5Data.elementRegistry && oElementsRegistryMasterView.setData(UI5Data.elementRegistry);
+            UI5Data.flexibilityInformation && oFlexibilityRegistryMasterView.setData(UI5Data.flexibilityInformation);
 
             controlProperties.setData(UI5Data.controlProperties || {});
             controlBindingInfoLeftDataView.setData(UI5Data.controlBindings || {});
@@ -543,6 +550,45 @@
     }
 
     // ================================================================================
+    // 'Flexibility information' tab
+    // ================================================================================
+
+    oFlexibilityHorizontalSplitter = new Splitter('flexibility-horizontal-splitter', {
+        endContainerWidth: '50%',
+        isEndContainerClosable: true,
+        hideEndContainer: true
+    });
+
+    oFlexibilityDetailView = new FlexibilityRegistryDetailView('flexibility-tab-detail');
+    oFlexibilityRegistryMasterView = new FlexibilityRegistryMasterView('flexibility-tab-master', {
+        /**
+         * Method fired when a flexibility entry is selected.
+         * @param {Object} data
+         */
+        onSelectItem: function (data) {
+            oFlexibilityHorizontalSplitter.showEndContainer();
+            oFlexibilityDetailView.update(data._original);
+        },
+
+        /**
+         * Clears all flexibility entry log items.
+         */
+        onClearItems: function () {
+            oFlexibilityDetailView.clear();
+            oFlexibilityHorizontalSplitter.hideEndContainer();
+        },
+
+        /**
+         * Downloads the registered flexibility changes.
+         */
+        onDownloadItems: function () {
+            port.postMessage({
+                action: 'do-flexibility-download'
+            });
+        }
+    });
+
+    // ================================================================================
     // Communication
     // ================================================================================
 
@@ -594,6 +640,7 @@
             frameData[frameId].controlTreeUI5 = message.controlTree;
             frameData[frameId].applicationInformation = message.applicationInformation;
             frameData[frameId].elementRegistry = message.elementRegistry;
+            frameData[frameId].flexibilityInformation = message.flexibilityInformation;
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
@@ -602,6 +649,7 @@
                 aiChat.setUrl(frameData[frameId].url);
                 appInfo.setData(message.applicationInformation);
                 oElementsRegistryMasterView.setData(message.elementRegistry);
+                oFlexibilityRegistryMasterView.setData(message.flexibilityInformation);
             }
         },
 
@@ -847,6 +895,21 @@
 
             if (bFrameUpdate) {
                 framesSelect.setData(frameData);
+            }
+        },
+
+        /**
+         * Updates the Flexibility Registry with the registered flexibility changes.
+         * @param {Object} message
+         */
+        'on-control-flexibility-property-change': function (message, messageSender) {
+            var frameId = messageSender.frameId;
+            if (!frameData[frameId]) {
+                return;
+            }
+            frameData[frameId].flexibilityInformation = message.flexibilityInformation;
+            if (framesSelect.getSelectedId() === frameId) {
+                oFlexibilityRegistryMasterView.setData(message.flexibilityInformation);
             }
         },
 

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -111,7 +111,8 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
                     action: 'on-receiving-initial-data',
                     applicationInformation: applicationUtils.getApplicationInfo(frameworkInformation),
                     controlTree: controlUtils.getControlTreeModel(controlTreeModel, frameworkInformation.commonInformation),
-                    elementRegistry: ToolsAPI.getRegisteredElements()
+                    elementRegistry: ToolsAPI.getRegisteredElements(),
+                    flexibilityInformation: ToolsAPI.getFlexibilityInformation()
                 });
             });
         },
@@ -239,6 +240,12 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
                 return;
             }
 
+            this['do-control-flexibility-property-change']({
+                detail: {
+                    data: oData
+                }
+            });
+
             _setControlProperties(oControl, oData);
 
             // Update the DevTools with the actual property value of the control
@@ -305,6 +312,49 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
         },
 
         /**
+         * Change control property, based on editing in the DataView.
+         * @param {Object} event
+         */
+        'do-control-flexibility-property-change': function (event) {
+            var oData = event.detail.data;
+            var sControlId = oData.controlId;
+            var sProperty = oData.property;
+            var vNewValue = oData.value;
+            var oControl = controlUtils.getElementById(sControlId);
+
+            if (!oControl) {
+                return;
+            }
+
+            var sControlClass = oControl.getMetadata().getName();
+            var sChangeType = 'propertyChange';
+            var sStateKey = [sControlId, sChangeType, sProperty].join('_');
+            var vInitialValue;
+
+            oData.controlClass = sControlClass;
+            oData.type = sChangeType;
+
+            if (ToolsAPI.isStateExists(sStateKey)) {
+                oData.initial = ToolsAPI.getStateValue(sStateKey) === vNewValue;
+            } else {
+                try {
+                    vInitialValue = oControl['get' + sProperty]();
+                    ToolsAPI.setStateValue(sStateKey, vInitialValue);
+                } catch (error) {
+                    // The control may not expose a getter for this property; ignore gracefully.
+                }
+                oData.initial = false;
+            }
+
+            ToolsAPI.addFlexibilityInformation(oData);
+
+            message.send({
+                action: 'on-control-flexibility-property-change',
+                flexibilityInformation: ToolsAPI.getFlexibilityInformation()
+            });
+        },
+
+        /**
          * Selects Control with context menu click.
          * @param {Object} event
          */
@@ -314,6 +364,13 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
                 target: event.detail.target,
                 frameId: event.detail.frameId
             });
+        },
+
+        /**
+         * Download the registered flexibility changes.
+         */
+        'do-flexibility-download': function () {
+            ToolsAPI.downloadFlexibilityInformation();
         },
 
         /**

--- a/app/scripts/modules/ui/FlexibilityRegistryDetailView.js
+++ b/app/scripts/modules/ui/FlexibilityRegistryDetailView.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * @param {string} containerId - id of the DOM container
+ * @constructor
+ */
+function FlexibilityRegistryDetailView(containerId) {
+    this.oContainer = document.getElementById(containerId);
+    this.oEditorDOM = document.createElement('div');
+    this.oEditorDOM.id = 'flexibility-editor';
+    this.oContainer.appendChild(this.oEditorDOM);
+
+    this.oEditor = ace.edit('flexibility-editor');
+    this.oEditor.getSession().setUseWrapMode(true);
+    this.oEditor.getSession().setTabSize(2);
+    this.oEditor.getSession().setMode('ace/mode/json');
+
+    this._setTheme();
+}
+
+/**
+ * Updates data.
+ * @param {Object} data - object structure as JSON
+ */
+FlexibilityRegistryDetailView.prototype.update = function (data) {
+    const oEditor = this.oEditor;
+    const oData = data;
+    const oDataJSON = JSON.stringify(oData, null, '\t');
+
+    oEditor.setValue(oDataJSON);
+};
+
+/**
+ * Clears editor.
+ */
+FlexibilityRegistryDetailView.prototype.clear = function () {
+    this.oEditor.setValue('', -1);
+};
+
+/**
+ * Sets theme.
+ */
+FlexibilityRegistryDetailView.prototype._setTheme = function () {
+    const bDarkMode = chrome.devtools.panels.themeName === 'dark';
+
+    this.oEditor.setTheme(bDarkMode ? 'ace/theme/vibrant_ink' : 'ace/theme/chrome');
+};
+
+module.exports = FlexibilityRegistryDetailView;

--- a/app/scripts/modules/ui/FlexibilityRegistryMasterView.js
+++ b/app/scripts/modules/ui/FlexibilityRegistryMasterView.js
@@ -1,0 +1,266 @@
+/* globals ResizeObserver */
+
+'use strict';
+
+const DataGrid = require('./datagrid/DataGrid.js');
+const UIUtils = require('./datagrid/UIUtils.js');
+
+const COLUMNS = [{
+    id: 'changeType',
+    title: 'changeType',
+    sortable: true,
+    align: undefined,
+    nonSelectable: false,
+    weight: 30,
+    visible: true,
+    allowInSortByEvenWhenHidden: false,
+    disclosure: true,
+    /**
+     * Sorts Items.
+     * @param {Object} a
+     * @param {Object} b
+     */
+    sortingFunction: function (a, b) {
+        return DataGrid.SortableDataGrid.StringComparator('changeType', a, b);
+    }
+}, {
+    id: 'selector.id',
+    title: 'selector.id',
+    sortable: true,
+    align: undefined,
+    nonSelectable: false,
+    weight: 20,
+    visible: true,
+    allowInSortByEvenWhenHidden: false,
+    /**
+     * Sorts Items.
+     * @param {Object} a
+     * @param {Object} b
+     */
+    sortingFunction: function (a, b) {
+        return DataGrid.SortableDataGrid.StringComparator('selector.id', a, b);
+    }
+}, {
+    id: 'selector.type',
+    title: 'selector.type',
+    sortable: true,
+    align: undefined,
+    nonSelectable: false,
+    weight: 20,
+    visible: true,
+    allowInSortByEvenWhenHidden: false,
+    /**
+     * Sorts Items.
+     * @param {Object} a
+     * @param {Object} b
+     */
+    sortingFunction: function (a, b) {
+        return DataGrid.SortableDataGrid.StringComparator('selector.type', a, b);
+    }
+}, {
+    id: 'content.property',
+    title: 'content.property',
+    sortable: true,
+    align: undefined,
+    nonSelectable: false,
+    weight: 20,
+    visible: true,
+    allowInSortByEvenWhenHidden: false,
+    /**
+     * Sorts Items.
+     * @param {Object} a
+     * @param {Object} b
+     */
+    sortingFunction: function (a, b) {
+        return DataGrid.SortableDataGrid.StringComparator('content.property', a, b);
+    }
+}, {
+    id: 'content.newValue',
+    title: 'content.newValue',
+    sortable: true,
+    align: undefined,
+    nonSelectable: false,
+    weight: 20,
+    visible: true,
+    allowInSortByEvenWhenHidden: false,
+    /**
+     * Sorts Items.
+     * @param {Object} a
+     * @param {Object} b
+     */
+    sortingFunction: function (a, b) {
+        return DataGrid.SortableDataGrid.StringComparator('content.newValue', a, b);
+    }
+}];
+
+/**
+ * @param {string} domId - id of the DOM container
+ * @param {Object} options - initial configuration
+ * @constructor
+ */
+function FlexibilityRegistryMasterView(domId, options) {
+
+    this.oContainerDOM = document.getElementById(domId);
+    this._data = [];
+
+    /**
+     * Selects a flexibility entry log item.
+     * @param {Object} oSelectedData
+     */
+    this.onSelectItem = function (oSelectedData) {};
+
+    /**
+     * Clears all flexibility entry log items.
+     */
+    this.onClearItems = function () {};
+
+    /**
+     * Downloads all flexibility entry log items.
+     */
+    this.onDownloadItems = function () {};
+
+    if (options) {
+        this.onSelectItem = options.onSelectItem || this.onSelectItem;
+        this.onClearItems = options.onClearItems || this.onClearItems;
+        this.onDownloadItems = options.onDownloadItems || this.onDownloadItems;
+    }
+
+    const oDownloadButton = this._createDownloadButton();
+    const oClearButton = this._createClearButton();
+    this.oContainerDOM.appendChild(oDownloadButton);
+    this.oContainerDOM.appendChild(oClearButton);
+
+    this.oDataGrid = this._createDataGrid();
+    this.oContainerDOM.appendChild(this.oDataGrid.element);
+}
+
+/**
+ * Gets the currently registered flexibility changes.
+ * @returns {Array}
+ */
+FlexibilityRegistryMasterView.prototype.getData = function () {
+    return this._data;
+};
+
+/**
+ * Sets the registered flexibility changes.
+ * @param {Array} data
+ * @returns {Object} - the view instance
+ */
+FlexibilityRegistryMasterView.prototype.setData = function (data) {
+    const oldData = this.getData();
+    const aData = Array.isArray(data) ? data : [];
+
+    if (JSON.stringify(oldData) === JSON.stringify(aData)) {
+        return;
+    }
+
+    this._data = aData;
+    this.oDataGrid.rootNode().removeChildren();
+
+    this._data.forEach(function (oElement) {
+        const oNode = new DataGrid.SortableDataGridNode(oElement);
+        if (oNode) {
+            this.oDataGrid.insertChild(oNode);
+        }
+    }, this);
+
+    return this;
+};
+
+/**
+ * Creates Clear button.
+ * @returns {Object} - Clear button Icon
+ * @private
+ */
+FlexibilityRegistryMasterView.prototype._createClearButton = function () {
+    const oIcon = UIUtils.Icon.create('', 'toolbar-glyph hidden');
+    oIcon.setIconType('largeicon-clear');
+
+    /**
+     * Clear Icon click handler.
+     */
+    oIcon.onclick = function () {
+        this.oDataGrid.rootNode().removeChildren();
+        this.onClearItems();
+    }.bind(this);
+
+    return oIcon;
+};
+
+/**
+ * Creates Download button.
+ * @returns {Object} - Download button Icon
+ * @private
+ */
+FlexibilityRegistryMasterView.prototype._createDownloadButton = function () {
+    const oIcon = UIUtils.Icon.create('', 'toolbar-glyph hidden');
+    oIcon.setIconType('largeicon-download');
+
+    /**
+     * Download Icon click handler.
+     */
+    oIcon.onclick = function () {
+        this.onDownloadItems();
+    }.bind(this);
+
+    return oIcon;
+};
+
+/**
+ * Creates DataGrid.
+ * @returns {Object} - DataGrid
+ * @private
+ */
+FlexibilityRegistryMasterView.prototype._createDataGrid = function () {
+    const oDataGrid = new DataGrid.SortableDataGrid({
+        displayName: 'test',
+        columns: COLUMNS
+    });
+
+    oDataGrid.addEventListener(DataGrid.Events.SortingChanged, this.sortHandler, this);
+    oDataGrid.addEventListener(DataGrid.Events.SelectedNode, this.selectHandler, this);
+
+    /**
+     * Resize Handler for DataGrid.
+     */
+    const oResizeObserver = new ResizeObserver(function () {
+        oDataGrid.onResize();
+    });
+    oResizeObserver.observe(oDataGrid.element);
+
+    return oDataGrid;
+};
+
+/**
+ * Sorts Columns of the DataGrid.
+ */
+FlexibilityRegistryMasterView.prototype.sortHandler = function () {
+    const columnId = this.oDataGrid.sortColumnId();
+
+    /**
+     * Finds Column config by Id.
+     * @param {Object} columnConfig
+     */
+    const columnConfig = COLUMNS.find(columnConfig => columnConfig.id === columnId);
+    if (!columnConfig || !columnConfig.sortingFunction) {
+        return;
+    }
+    this.oDataGrid.sortNodes(columnConfig.sortingFunction, !this.oDataGrid.isSortOrderAscending());
+};
+
+/**
+ * Selects clicked log entry.
+ * @param {Object} oEvent
+ */
+FlexibilityRegistryMasterView.prototype.selectHandler = function (oEvent) {
+    const oSelectedNode = oEvent.data;
+
+    if (!oSelectedNode) {
+        return;
+    }
+
+    this.onSelectItem(oSelectedNode.data);
+};
+
+module.exports = FlexibilityRegistryMasterView;

--- a/app/scripts/modules/ui/datagrid/UIUtils.js
+++ b/app/scripts/modules/ui/datagrid/UIUtils.js
@@ -393,7 +393,8 @@ const Descriptors = {
     'mediumicon-red-cross-active': {position: 'd2', spritesheet: 'mediumicons'},
     'mediumicon-red-cross-hover': {position: 'a1', spritesheet: 'mediumicons'},
     'largeicon-clear': {position: 'a6', spritesheet: 'largeicons', isMask: true},
-    'largeicon-refresh': {position: 'd2', spritesheet: 'largeicons', isMask: true}
+    'largeicon-refresh': {position: 'd2', spritesheet: 'largeicons', isMask: true},
+    'largeicon-download': {position: 'h6', spritesheet: 'largeicons', isMask: true}
 };
 
 

--- a/app/scripts/modules/utils/utils.js
+++ b/app/scripts/modules/utils/utils.js
@@ -18,11 +18,11 @@ function _resolveMessage(options) {
         return;
     }
 
-    var message = options.message;
-    var messageSender = options.messageSender;
-    var sendResponse = options.sendResponse;
-    var actions = options.actions;
-    var messageHandlerFunction = actions[message.action];
+    const message = options.message;
+    const messageSender = options.messageSender;
+    const sendResponse = options.sendResponse;
+    const actions = options.actions;
+    const messageHandlerFunction = actions[message.action];
 
     if (messageHandlerFunction) {
         messageHandlerFunction(message, messageSender, sendResponse);
@@ -36,7 +36,7 @@ function _resolveMessage(options) {
  * @private
  */
 function _convertUI5TimeStampToHumanReadableFormat(timeStamp) {
-    var formattedTime = '';
+    let formattedTime = '';
 
     if (!timeStamp) {
         return;
@@ -67,7 +67,7 @@ function _convertUI5TimeStampToHumanReadableFormat(timeStamp) {
  */
 function _setOSClassNameToBody() {
     // Set a body attribute for detecting and styling according the OS
-    var osName = '';
+    let osName = '';
     if (navigator.appVersion.indexOf('Win') !== -1) {
         osName = 'windows';
     }
@@ -86,10 +86,10 @@ function _setOSClassNameToBody() {
  * @private
  */
 function _applyTheme(theme) {
-    var oldLink = document.getElementById('ui5inspector-theme');
-    var head = document.getElementsByTagName('head')[0];
-    var link = document.createElement('link');
-    var url = '/styles/themes/light/light.css';
+    let oldLink = document.getElementById('ui5inspector-theme');
+    let head = document.getElementsByTagName('head')[0];
+    let link = document.createElement('link');
+    let url = '/styles/themes/light/light.css';
 
     if (oldLink) {
         oldLink.remove();
@@ -128,8 +128,8 @@ function _getPort () {
  * @param {Object} message
  */
 function _sendToAll(message, callback) {
-    var frameId = message.frameId;
-    var options;
+    const frameId = message.frameId;
+    let options;
     chrome.windows.getCurrent().then(w => {
         chrome.tabs.query({ active: true, windowId: w.id }).then(tabs => {
             // options.frameId allows to send the message to

--- a/app/styles/less/modules/FlexibilityRegistry.less
+++ b/app/styles/less/modules/FlexibilityRegistry.less
@@ -1,0 +1,76 @@
+flexibility-master-view,
+flexibility-detail-view {
+    height: 100%;
+}
+
+.flexibilityTab {
+    flex-direction: column;
+    background-color: @bg-datagrid;
+    color: @text-color;
+
+    * { min-width: 0px; min-height: 0px; }
+    * { box-sizing: border-box; }
+    :focus { outline-width: 0px; }
+    [is="ui-icon"] { display: inline-block; flex-shrink: 0; }
+    [is="ui-icon"].icon-mask { background-color: rgb(110, 110, 110); -webkit-mask-position: var(--spritesheet-position); }
+    .spritesheet-smallicons:not(.icon-mask) { background-image: url("/images/smallIcons.svg"); }
+    .spritesheet-smallicons.icon-mask { -webkit-mask-image: url("/images/smallIcons.svg"); }
+    .spritesheet-largeicons.icon-mask { -webkit-mask-image: url("/images/largeIcons.svg"); }
+    .spritesheet-mediumicons.icon-mask { -webkit-mask-image: url("/images/mediumIcons.svg"); }
+    .spritesheet-mediumicons:not(.icon-mask) { background-image: url(/images/mediumIcons.svg); }
+    [is=ui-icon]:not(.icon-mask) { background-position: var(--spritesheet-position); }
+    cursor: default; font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", sans-serif; font-size: 12px; tab-size: 4; user-select: none;
+    ::selection { background-color: @bg-datagrid; }
+
+    .data-grid:focus {
+        outline: none;
+    }
+
+    splitter {
+        background-color: @bg-datagrid-header;
+    }
+
+    splitter start {
+        flex-direction: column;
+    }
+
+    splitter > start [is="ui-icon"] {
+        height: 1.3rem;
+        width: 1.3rem;
+        padding-top: 0.15rem;
+        padding-left: 0.15rem;
+        font-size: 0.9rem;
+        cursor: pointer;
+        opacity: 0.7;
+        transition: opacity 0.2s;
+        color: #838181;
+        font-weight: bold;
+        display: block;
+    }
+
+    splitter > start [is="ui-icon"]:hover {
+        opacity: 1;
+    }
+
+    .data-grid {
+        position: absolute;
+        top: 25px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: auto;
+    }
+
+    #flexibility-editor {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: auto;
+    }
+
+    table {
+        width: 100%;
+    }
+}

--- a/app/styles/less/themes/base/base.less
+++ b/app/styles/less/themes/base/base.less
@@ -17,5 +17,6 @@
 @import "../../modules/XMLView.less";
 @import "../../modules/DataGrid.less";
 @import "../../modules/ElementsRegistry.less";
+@import "../../modules/FlexibilityRegistry.less";
 @import "../../modules/AIChat.less";
 

--- a/app/vendor/ToolsAPI.js
+++ b/app/vendor/ToolsAPI.js
@@ -1,5 +1,5 @@
-sap.ui.define(["sap/ui/core/Core", "sap/ui/core/Element", "sap/ui/core/ElementMetadata"],
-    function (Core, Element, ElementMetadata) {
+sap.ui.define(["sap/ui/core/Core", "sap/ui/core/Element", "sap/ui/core/ElementMetadata", "sap/ui/core/util/File", "sap/ui/thirdparty/jszip"],
+    function (Core, Element, ElementMetadata, File, JSZip) {
         "use strict";
 
         var BaseConfig = sap.ui.require('sap/base/config/_Configuration');
@@ -1088,6 +1088,316 @@ sap.ui.define(["sap/ui/core/Core", "sap/ui/core/Element", "sap/ui/core/ElementMe
             }
         }
 
+        var stateRegistry = {
+            states: {},
+
+            /**
+             * Checks whether a state with the given key is registered.
+             * @param {string} sStateKey
+             * @returns {boolean}
+             */
+            isStateExists: function (sStateKey) {
+                return stateRegistry.states.hasOwnProperty(sStateKey);
+            },
+
+            /**
+             * Stores a state value under the given key.
+             * @param {string} sStateKey
+             * @param {*} sStateValue
+             */
+            setStateValue: function (sStateKey, sStateValue) {
+                stateRegistry.states[sStateKey] = sStateValue;
+            },
+
+            /**
+             * Returns the state value stored under the given key.
+             * @param {string} sStateKey
+             * @returns {*}
+             */
+            getStateValue: function (sStateKey) {
+                return stateRegistry.states[sStateKey];
+            }
+        };
+
+        var flexibilityRegistry = {
+            changes: [],
+
+            /**
+             * Flattens the nested structure of a change object into a flat key-value map.
+             * @param {Object} currentNode
+             * @param {Object} target
+             * @param {string} [flattenedKey]
+             */
+            traverseAndFlatten: function traverseAndFlatten(currentNode, target, flattenedKey) {
+                for (var key in currentNode) {
+                    if (currentNode.hasOwnProperty(key)) {
+                        var newKey;
+                        if (flattenedKey === undefined) {
+                            newKey = key;
+                        } else {
+                            newKey = flattenedKey + '.' + key;
+                        }
+
+                        var value = currentNode[key];
+                        if (typeof value === "object") {
+                            flexibilityRegistry.traverseAndFlatten(value, target, newKey);
+                        } else {
+                            target[newKey] = value;
+                        }
+                    }
+                }
+            },
+
+            /**
+             * Returns all registered flexibility changes.
+             * @returns {Array}
+             */
+            getRegisteredChanges: function () {
+                return flexibilityRegistry.changes;
+            },
+
+            /**
+             * Returns the registered flexibility changes, flattened for the DataGrid.
+             * @returns {Array}
+             */
+            getFlexibilityInformation: function () {
+                var aChanges = flexibilityRegistry.getRegisteredChanges();
+
+                return aChanges.map(function (oFileContent) {
+                    var oFlattedFileContent = {};
+                    flexibilityRegistry.traverseAndFlatten(oFileContent, oFlattedFileContent);
+                    oFlattedFileContent["content.newValue"] = String(oFlattedFileContent["content.newValue"]);
+                    oFlattedFileContent._original = jQuery.extend(true, {}, oFileContent);
+                    return oFlattedFileContent;
+                });
+            },
+
+            /**
+             * Finds a registered change by file name.
+             * @param {Object} oFileContent
+             * @returns {Object|undefined}
+             */
+            findByFileName: function (oFileContent) {
+                return flexibilityRegistry.getRegisteredChanges().find(function (oChange) {
+                    return oChange.fileName === oFileContent.fileName;
+                });
+            },
+
+            /**
+             * Finds a registered change by selector and property.
+             * @param {Object} oFileContent
+             * @returns {Object|undefined}
+             */
+            findBySelectorProperty: function (oFileContent) {
+                return flexibilityRegistry.getRegisteredChanges().find(function (oChange) {
+                    return oChange.selector.id === oFileContent.selector.id &&
+                        oChange.content.property === oFileContent.content.property;
+                });
+            },
+            createFileContent: function (data) {
+                var creationDate = new Date();
+                var creationDateISO = creationDate.toISOString();
+                var creationDateTime = creationDate.getTime();
+                var oFileContent = {};
+
+                var getAppLifeCycleService = function () {
+                    var oUShellContainer = jQuery.sap.getObject("sap.ushell.Container");
+                    var oAppLifeCycle;
+
+                    if (oUShellContainer) {
+                        oAppLifeCycle = oUShellContainer.getService("AppLifeCycle");
+                    }
+                    return oAppLifeCycle;
+                };
+
+                var getComponentName = function () {
+                    var oAppLifeCycle = getAppLifeCycleService();
+                    var oCurrentApplication;
+                    var oComponentInstance;
+                    var sComponentName = "";
+
+                    if (oAppLifeCycle) {
+                        oCurrentApplication = oAppLifeCycle.getCurrentApplication();
+                    }
+                    if (oCurrentApplication) {
+                        oComponentInstance = oCurrentApplication.componentInstance;
+                    }
+                    if (oComponentInstance) {
+                        sComponentName = oComponentInstance.getMetadata().getName();
+                    }
+                    return sComponentName;
+                };
+
+                var getChangeType = function () {
+                    return data.type;
+                };
+
+                var getReference = function () {
+                    return getComponentName();
+                };
+
+                var getProjectId = function () {
+                    var sComponentName = getComponentName();
+
+                    return sComponentName.split(".").slice(0, -1).join(".");
+                };
+
+                var getNamespace = function () {
+                    return "apps/" + getProjectId() + "/changes/";
+                };
+
+                var getProperty = function () {
+                    var sProperty = String(data.property);
+
+                    return sProperty.charAt(0).toLowerCase() + sProperty.substring(1);
+                };
+
+                var getOriginalLanguage = function () {
+                    var sLanguage = _getLanguage();
+
+                    return sLanguage ? String(sLanguage).toUpperCase() : "EN";
+                };
+
+                var getSapUi5Version = function () {
+                    var vVersion = _getVersion();
+
+                    return vVersion ? String(vVersion) : "";
+                };
+
+                var getFileName = function () {
+                    return "id_" + creationDateTime + "_" + getChangeType();
+                };
+
+                switch (getChangeType()) {
+                    case "propertyChange":
+                    case "propertyBindingChange":
+                        jQuery.extend(true, oFileContent, {
+                            "fileName": getFileName(),
+                            "fileType": "change",
+                            "changeType": getChangeType(),
+                            "moduleName": "",
+                            "reference": getReference(),
+                            "packageName": "$TMP",
+                            "content": {
+                                "property": getProperty(),
+                                "newValue": data.value
+                            },
+                            "selector": {
+                                "id": data.controlId,
+                                "type": data.controlClass,
+                                "idIsLocal": false
+                            },
+                            "layer": "VENDOR",
+                            "texts": {},
+                            "namespace": getNamespace(),
+                            "projectId": getProjectId(),
+                            "creation": creationDateISO,
+                            "originalLanguage": getOriginalLanguage(),
+                            "conditions": {},
+                            "context": "",
+                            "support": {
+                                "generator": "Change.createInitialFileContent",
+                                "service": "",
+                                "user": "",
+                                "sapui5Version": getSapUi5Version(),
+                                "sourceChangeFileName": "",
+                                "compositeCommand": ""
+                            },
+                            "oDataInformation": {},
+                            "dependentSelector": {},
+                            "validAppVersions": {
+                                "creation": "1.0.0",
+                                "from": "1.0.0",
+                                "to": "1.0.0"
+                            },
+                            "jsOnly": false,
+                            "variantReference": "",
+                            "appDescriptorChange": false
+                        });
+                        break;
+
+                    default:
+                        break;
+                }
+                return oFileContent;
+            },
+
+            /**
+             * Registers a flexibility change.
+             * @param {Object} data - change data from the DataView
+             */
+            addFlexibilityInformation: function (data) {
+                var aChanges = flexibilityRegistry.getRegisteredChanges();
+                var oNewFile = flexibilityRegistry.createFileContent(data);
+                var oOldFile = flexibilityRegistry.findBySelectorProperty(oNewFile);
+
+                if (oOldFile) {
+                    flexibilityRegistry.removeFlexibilityInformation(oOldFile);
+                }
+
+                if (data.initial) {
+                    return;
+                }
+
+                aChanges.push(oNewFile);
+            },
+
+            /**
+             * Removes a registered flexibility change.
+             * @param {Object} oFileContent
+             */
+            removeFlexibilityInformation: function (oFileContent) {
+                if (!oFileContent) {
+                    return;
+                }
+                var aChanges = flexibilityRegistry.getRegisteredChanges();
+                var oChange = flexibilityRegistry.findByFileName(oFileContent);
+                var iIndex = aChanges.indexOf(oChange);
+
+                if (iIndex !== -1) {
+                    aChanges.splice(iIndex, 1);
+                }
+            },
+
+            /**
+             * Downloads all registered flexibility changes as a zip archive.
+             */
+            downloadFlexibilityInformation: function () {
+                var aChanges = flexibilityRegistry.getRegisteredChanges();
+                var JSZipConstructor = JSZip || window.JSZip;
+                var oZipFile = new JSZipConstructor();
+
+                aChanges.forEach(function (oFileContent) {
+                    var sFullFileName = oFileContent.fileName + ".change";
+
+                    oZipFile.file(sFullFileName, JSON.stringify(oFileContent, null, "\t"));
+                });
+
+                var fnSaveZip = function (oZipBlob) {
+                    // Save the zip archive
+                    var oFileInfo = {
+                        blob: oZipBlob,
+                        name: "FlexibilityRegistry",
+                        extension: "zip",
+                        mimeType: "application/zip"
+                    };
+
+                    File.save(oFileInfo.blob, oFileInfo.name, oFileInfo.extension, oFileInfo.mimeType);
+                };
+
+                var fnGenerateZip = function () {
+                    if (oZipFile.generateAsync) {
+                        return oZipFile.generateAsync({type: "blob"});
+                    }
+                    return oZipFile.generate({type: "blob"});
+                };
+
+                Promise.resolve()
+                    .then(fnGenerateZip)
+                    .then(fnSaveZip);
+            }
+        }
+
         // ================================================================================
         // Public API
         // ================================================================================
@@ -1174,6 +1484,52 @@ sap.ui.define(["sap/ui/core/Core", "sap/ui/core/Element", "sap/ui/core/ElementMe
                 return controlInformation._getEvents(controlId);
             },
 
+            getRegisteredElements: elementRegistry.getRegisteredElements,
+
+            /**
+             * Returns the registered flexibility changes, flattened for the DataGrid.
+             * @returns {Array}
+             */
+            getFlexibilityInformation: flexibilityRegistry.getFlexibilityInformation,
+
+            /**
+             * Registers a flexibility change.
+             * @param {Object} data - change data from the DataView
+             */
+            addFlexibilityInformation: flexibilityRegistry.addFlexibilityInformation,
+
+            /**
+             * Removes a registered flexibility change.
+             * @param {Object} oFileContent
+             */
+            removeFlexibilityInformation: flexibilityRegistry.removeFlexibilityInformation,
+
+            /**
+             * Downloads all registered flexibility changes as a zip archive.
+             */
+            downloadFlexibilityInformation: flexibilityRegistry.downloadFlexibilityInformation,
+
+            /**
+             * Checks whether a state with the given key is registered.
+             * @param {string} sStateKey
+             * @returns {boolean}
+             */
+            isStateExists: stateRegistry.isStateExists,
+
+            /**
+             * Stores a state value under the given key.
+             * @param {string} sStateKey
+             * @param {*} sStateValue
+             */
+            setStateValue: stateRegistry.setStateValue,
+
+            /**
+             * Returns the state value stored under the given key.
+             * @param {string} sStateKey
+             * @returns {*}
+             */
+            getStateValue: stateRegistry.getStateValue,
+
             /**
              * Removes event listeners from the controls.
              * @param {string} controlId
@@ -1197,9 +1553,7 @@ sap.ui.define(["sap/ui/core/Core", "sap/ui/core/Element", "sap/ui/core/ElementMe
              */
             clearEvents: function(controlId) {
                 return controlInformation._clearEvents(controlId);
-            },
-
-            getRegisteredElements: elementRegistry.getRegisteredElements
+            }
         };
 
     });

--- a/tests/modules/ui/FlexibilityRegistryDetailView.spec.js
+++ b/tests/modules/ui/FlexibilityRegistryDetailView.spec.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const FlexibilityRegistryDetailView = require('../../../app/scripts/modules/ui/FlexibilityRegistryDetailView.js');
+
+describe('FlexibilityRegistryDetailView', function () {
+    var fixtures = document.getElementById('fixtures');
+    var editor;
+    var view;
+    var originalAce;
+    var originalChrome;
+
+    beforeEach(function () {
+        fixtures.innerHTML = '<div id="flexibility-tab-detail"></div>';
+
+        originalAce = window.ace;
+        originalChrome = window.chrome;
+
+        editor = {
+            session: {
+                setUseWrapMode: sinon.spy(),
+                setTabSize: sinon.spy(),
+                setMode: sinon.spy()
+            },
+            setTheme: sinon.spy(),
+            setValue: sinon.spy(),
+            getSession: function () {
+                return this.session;
+            }
+        };
+
+        window.ace = {
+            edit: sinon.stub().returns(editor)
+        };
+
+        window.chrome = {
+            devtools: {
+                panels: {
+                    themeName: 'light'
+                }
+            }
+        };
+
+        view = new FlexibilityRegistryDetailView('flexibility-tab-detail');
+    });
+
+    afterEach(function () {
+        fixtures.innerHTML = '';
+        if (originalAce === undefined) {
+            delete window.ace;
+        } else {
+            window.ace = originalAce;
+        }
+        window.chrome = originalChrome;
+    });
+
+    describe('Constructor', function () {
+        it('should create an ace editor inside the container', function () {
+            window.ace.edit.calledWith('flexibility-editor').should.equal(true);
+        });
+
+        it('should configure the editor session', function () {
+            editor.session.setUseWrapMode.calledWith(true).should.equal(true);
+            editor.session.setTabSize.calledWith(2).should.equal(true);
+            editor.session.setMode.calledWith('ace/mode/json').should.equal(true);
+        });
+
+        it('should apply the light theme by default', function () {
+            editor.setTheme.calledWith('ace/theme/chrome').should.equal(true);
+        });
+    });
+
+    describe('update', function () {
+        it('should set the JSON stringified data in the editor', function () {
+            var data = { changeType: 'propertyChange' };
+
+            view.update(data);
+
+            editor.setValue.calledWith(JSON.stringify(data, null, '\t')).should.equal(true);
+        });
+    });
+
+    describe('clear', function () {
+        it('should clear the editor content', function () {
+            view.clear();
+
+            editor.setValue.calledWith('', -1).should.equal(true);
+        });
+    });
+
+    describe('_setTheme', function () {
+        it('should apply the dark theme in dark mode', function () {
+            window.chrome.devtools.panels.themeName = 'dark';
+
+            view._setTheme();
+
+            editor.setTheme.calledWith('ace/theme/vibrant_ink').should.equal(true);
+        });
+    });
+});

--- a/tests/modules/ui/FlexibilityRegistryMasterView.spec.js
+++ b/tests/modules/ui/FlexibilityRegistryMasterView.spec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const FlexibilityRegistryMasterView = require('../../../app/scripts/modules/ui/FlexibilityRegistryMasterView.js');
+
+describe('FlexibilityRegistryMasterView', function () {
+    var fixtures = document.getElementById('fixtures');
+    var view;
+
+    beforeEach(function () {
+        fixtures.innerHTML = '<div id="flexibility-tab-master"></div>';
+
+        view = new FlexibilityRegistryMasterView('flexibility-tab-master');
+    });
+
+    afterEach(function () {
+        fixtures.innerHTML = '';
+    });
+
+    describe('Constructor', function () {
+        it('should have a default no-op onSelectItem callback', function () {
+            view.onSelectItem.should.be.a('function');
+            (function () { view.onSelectItem({}); }).should.not.throw();
+        });
+
+        it('should have a default no-op onClearItems callback', function () {
+            view.onClearItems.should.be.a('function');
+            (function () { view.onClearItems(); }).should.not.throw();
+        });
+
+        it('should have a default no-op onDownloadItems callback', function () {
+            view.onDownloadItems.should.be.a('function');
+            (function () { view.onDownloadItems(); }).should.not.throw();
+        });
+
+        it('should overwrite the callbacks if provided in options', function () {
+            var called = 0;
+            var v = new FlexibilityRegistryMasterView('flexibility-tab-master', {
+                onSelectItem: function () { called++; },
+                onClearItems: function () { called++; },
+                onDownloadItems: function () { called++; }
+            });
+
+            v.onSelectItem({});
+            v.onClearItems();
+            v.onDownloadItems();
+
+            called.should.equal(3);
+        });
+
+        it('should render the download and clear buttons and the DataGrid', function () {
+            view.oContainerDOM.querySelector('.largeicon-download').should.exist;
+            view.oContainerDOM.querySelector('.largeicon-clear').should.exist;
+            view.oDataGrid.element.should.exist;
+        });
+    });
+
+    describe('setData', function () {
+        it('should store the given data', function () {
+            var data = [{ changeType: 'propertyChange' }];
+
+            view.setData(data);
+
+            view.getData().should.equal(data);
+        });
+
+        it('should insert a node for every registered change', function () {
+            view.setData([{ changeType: 'propertyChange' }, { changeType: 'propertyBindingChange' }]);
+
+            view.oDataGrid.rootNode().children.length.should.equal(2);
+        });
+
+        it('should not insert duplicate nodes when the same data is set again', function () {
+            var data = [{ changeType: 'propertyChange' }];
+
+            view.setData(data);
+            view.setData(data);
+
+            view.oDataGrid.rootNode().children.length.should.equal(1);
+        });
+
+        it('should handle undefined data without throwing', function () {
+            (function () { view.setData(undefined); }).should.not.throw();
+
+            view.oDataGrid.rootNode().children.length.should.equal(0);
+        });
+
+        it('should handle null data without throwing', function () {
+            (function () { view.setData(null); }).should.not.throw();
+        });
+
+        it('should be chainable', function () {
+            view.setData([{ changeType: 'propertyChange' }]).should.equal(view);
+        });
+    });
+
+    describe('selectHandler', function () {
+        it('should call onSelectItem with the selected node data', function () {
+            var selected = null;
+            var data = { changeType: 'propertyChange' };
+            var v = new FlexibilityRegistryMasterView('flexibility-tab-master', {
+                onSelectItem: function (oData) { selected = oData; }
+            });
+
+            v.selectHandler({ data: { data: data } });
+
+            selected.should.equal(data);
+        });
+
+        it('should not throw when the event has no selected node', function () {
+            (function () { view.selectHandler({ data: undefined }); }).should.not.throw();
+        });
+    });
+
+    describe('Clear button', function () {
+        it('should remove all grid nodes and call onClearItems', function () {
+            var cleared = false;
+
+            fixtures.innerHTML = '<div id="flexibility-tab-master"></div>';
+            var v = new FlexibilityRegistryMasterView('flexibility-tab-master', {
+                onClearItems: function () { cleared = true; }
+            });
+
+            v.setData([{ changeType: 'propertyChange' }, { changeType: 'propertyBindingChange' }]);
+            v.oDataGrid.rootNode().children.length.should.equal(2);
+
+            v.oContainerDOM.querySelector('.largeicon-clear').onclick();
+
+            cleared.should.equal(true);
+            v.oDataGrid.rootNode().children.length.should.equal(0);
+        });
+    });
+});

--- a/tests/styles/themes/dark/dark.css
+++ b/tests/styles/themes/dark/dark.css
@@ -1270,6 +1270,103 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .elementsRegistry splitter {
   background-color: #000;
 }
+flexibility-master-view,
+flexibility-detail-view {
+  height: 100%;
+}
+.flexibilityTab {
+  flex-direction: column;
+  background-color: #252525;
+  color: #949494;
+  cursor: default;
+  font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", sans-serif;
+  font-size: 12px;
+  tab-size: 4;
+  user-select: none;
+}
+.flexibilityTab * {
+  min-width: 0px;
+  min-height: 0px;
+}
+.flexibilityTab * {
+  box-sizing: border-box;
+}
+.flexibilityTab :focus {
+  outline-width: 0px;
+}
+.flexibilityTab [is="ui-icon"] {
+  display: inline-block;
+  flex-shrink: 0;
+}
+.flexibilityTab [is="ui-icon"].icon-mask {
+  background-color: #6e6e6e;
+  -webkit-mask-position: var(--spritesheet-position);
+}
+.flexibilityTab .spritesheet-smallicons:not(.icon-mask) {
+  background-image: url("/images/smallIcons.svg");
+}
+.flexibilityTab .spritesheet-smallicons.icon-mask {
+  -webkit-mask-image: url("/images/smallIcons.svg");
+}
+.flexibilityTab .spritesheet-largeicons.icon-mask {
+  -webkit-mask-image: url("/images/largeIcons.svg");
+}
+.flexibilityTab .spritesheet-mediumicons.icon-mask {
+  -webkit-mask-image: url("/images/mediumIcons.svg");
+}
+.flexibilityTab .spritesheet-mediumicons:not(.icon-mask) {
+  background-image: url(/images/mediumIcons.svg);
+}
+.flexibilityTab [is=ui-icon]:not(.icon-mask) {
+  background-position: var(--spritesheet-position);
+}
+.flexibilityTab ::selection {
+  background-color: #252525;
+}
+.flexibilityTab .data-grid:focus {
+  outline: none;
+}
+.flexibilityTab splitter {
+  background-color: #000;
+}
+.flexibilityTab splitter start {
+  flex-direction: column;
+}
+.flexibilityTab splitter > start [is="ui-icon"] {
+  height: 1.3rem;
+  width: 1.3rem;
+  padding-top: 0.15rem;
+  padding-left: 0.15rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+  color: #838181;
+  font-weight: bold;
+  display: block;
+}
+.flexibilityTab splitter > start [is="ui-icon"]:hover {
+  opacity: 1;
+}
+.flexibilityTab .data-grid {
+  position: absolute;
+  top: 25px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
+.flexibilityTab #flexibility-editor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
+.flexibilityTab table {
+  width: 100%;
+}
 .ai-chat-wrapper {
   display: flex;
   flex-direction: column;

--- a/tests/styles/themes/light/light.css
+++ b/tests/styles/themes/light/light.css
@@ -1270,6 +1270,103 @@ elements-registry-master-view:not([show-filtered-elements]) .selected ::selectio
 .elementsRegistry splitter {
   background-color: #f2f2f2;
 }
+flexibility-master-view,
+flexibility-detail-view {
+  height: 100%;
+}
+.flexibilityTab {
+  flex-direction: column;
+  background-color: #fff;
+  color: #222;
+  cursor: default;
+  font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", sans-serif;
+  font-size: 12px;
+  tab-size: 4;
+  user-select: none;
+}
+.flexibilityTab * {
+  min-width: 0px;
+  min-height: 0px;
+}
+.flexibilityTab * {
+  box-sizing: border-box;
+}
+.flexibilityTab :focus {
+  outline-width: 0px;
+}
+.flexibilityTab [is="ui-icon"] {
+  display: inline-block;
+  flex-shrink: 0;
+}
+.flexibilityTab [is="ui-icon"].icon-mask {
+  background-color: #6e6e6e;
+  -webkit-mask-position: var(--spritesheet-position);
+}
+.flexibilityTab .spritesheet-smallicons:not(.icon-mask) {
+  background-image: url("/images/smallIcons.svg");
+}
+.flexibilityTab .spritesheet-smallicons.icon-mask {
+  -webkit-mask-image: url("/images/smallIcons.svg");
+}
+.flexibilityTab .spritesheet-largeicons.icon-mask {
+  -webkit-mask-image: url("/images/largeIcons.svg");
+}
+.flexibilityTab .spritesheet-mediumicons.icon-mask {
+  -webkit-mask-image: url("/images/mediumIcons.svg");
+}
+.flexibilityTab .spritesheet-mediumicons:not(.icon-mask) {
+  background-image: url(/images/mediumIcons.svg);
+}
+.flexibilityTab [is=ui-icon]:not(.icon-mask) {
+  background-position: var(--spritesheet-position);
+}
+.flexibilityTab ::selection {
+  background-color: #fff;
+}
+.flexibilityTab .data-grid:focus {
+  outline: none;
+}
+.flexibilityTab splitter {
+  background-color: #f2f2f2;
+}
+.flexibilityTab splitter start {
+  flex-direction: column;
+}
+.flexibilityTab splitter > start [is="ui-icon"] {
+  height: 1.3rem;
+  width: 1.3rem;
+  padding-top: 0.15rem;
+  padding-left: 0.15rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+  color: #838181;
+  font-weight: bold;
+  display: block;
+}
+.flexibilityTab splitter > start [is="ui-icon"]:hover {
+  opacity: 1;
+}
+.flexibilityTab .data-grid {
+  position: absolute;
+  top: 25px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
+.flexibilityTab #flexibility-editor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
+.flexibilityTab table {
+  width: 100%;
+}
 .ai-chat-wrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation

When a developer changes a control property in the UI5 Inspector's Properties tab, that change currently lives only in the inspected page and is lost as soon as the page reloads. To persist such adjustments in an OpenUI5/SAPUI5 app, the developer had to export them manually into the `changes` folder of a flexibility/adaptation project — a tedious, error-prone process.

### What's new

A new **Flexibility Registry** tab in the UI5 panel (between Elements Registry and AI Assistant) that automatically records every property change made through the inspector and lets you export the result.

The tab consists of two panes:

- **Master view** — a sortable `DataGrid` listing each registered change with columns for `changeType`, `selector.id`, `selector.type`, `content.property` and `content.newValue`, plus **Download** and **Clear** toolbar buttons.
- **Detail view** — an ACE-based JSON editor that shows the full change-file content of the selected entry, following the light/dark DevTools theme.

### How it works

1. Whenever a control property is edited via the inspector's DataView, the injected script triggers a new `do-control-flexibility-property-change` action (`app/scripts/injected/main.js`).
2. The change is converted into a flexibility change file by the new `flexibilityRegistry` in `app/vendor/ToolsAPI.js`, using the same structure that `Change.createInitialFileContent` produces (`fileType: "change"`, `changeType: "propertyChange"`, `layer: "VENDOR"`, `packageName: "$TMP"`, `namespace: "apps/<projectId>/changes/"`, `support.generator: "Change.createInitialFileContent"`, etc.). The control class is read from the UI5 metadata and used as `selector.type`; the inspected app's component name is resolved via the `sap.ushell` AppLifeCycle service and used as `reference`.
3. A new `stateRegistry` keeps the first-observed value per `(controlId, changeType, property)`. Changes are de-duplicated by `(selector.id, content.property)`, and a property restored to its initial value is automatically removed from the list.
4. Clicking **Download** zips all registered changes into a single `FlexibilityRegistry.zip` (`sap/ui/core/util/File` + `JSZip`), where every change is a separate `id_<timestamp>_<changeType>.change` file. The archive can be unpacked directly into the `changes` folder of a flexibility/adaptation project in the Web IDE / Business Application Studio.

### API additions

New public `ToolsAPI` methods, all backed by unit-tested modules:

- `getFlexibilityInformation()` / `addFlexibilityInformation(data)` / `removeFlexibilityInformation(change)` — register, read and remove flexibility changes (the registry data is pushed to the panel per frame alongside the existing element registry).
- `downloadFlexibilityInformation()` — generate and save the zip archive.
- `isStateExists(key)` / `setStateValue(key, value)` / `getStateValue(key)` — initial-value tracking used to drop revert-to-initial edits.

### Wiring

- New tab markup and splitter in `app/html/panel/ui5/index.html`; the panel (`app/scripts/devtools/panel/ui5/main.js`) caches `flexibilityInformation` per frame, keeps the grid in sync via a new `on-control-flexibility-property-change` message, and forwards the download/clear/select actions.
- A new `largeicon-download` icon was added to the DataGrid sprite map (`app/scripts/modules/ui/datagrid/UIUtils.js`).
- Styles live in `app/styles/less/modules/FlexibilityRegistry.less` (imported in `base.less`); the compiled light/dark CSS was regenerated.

### Tests

- `tests/modules/ui/FlexibilityRegistryMasterView.spec.js` — constructor defaults/overrides, grid rendering, `setData` (incl. duplicate prevention and undefined/null input), selection handler, clear-button behavior.
- `tests/modules/ui/FlexibilityRegistryDetailView.spec.js` — editor creation/configuration, light/dark theme selection, `update` and `clear`.
- Existing `grunt test` / lint suites stay green.

### Authors

- **Denis Chubarov** — main functionality, created for the UI5 developer community in Telegram ([https://t.me/ui5_js](https://t.me/ui5_js)). Version 0.9.10. [LinkedIn](https://www.linkedin.com/in/denis-chubarov/)
- **Roman Nosov** — merged the outdated fork sources with the main repository and wrote the tests. [LinkedIn](https://www.linkedin.com/in/nosov-roman/)