### PR TITLE
feat: show per-runtime UI5 Web Components info in App Info tab

### DIFF
--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -2,6 +2,13 @@
 (function () {
     'use strict';
 
+    // This controller function was already at the configured maxstatements
+    // ceiling (60); adding the App Info merge helpers (WebC + classic UI5)
+    // tips it over. Raise the scoped limit rather than fragment the tightly
+    // coupled panel wiring — same approach as the maxcomplexity directives
+    // elsewhere in the codebase.
+    /* jshint maxstatements: 70 */
+
     // ================================================================================
     // Main controller for 'UI5' tab in devtools
     // ================================================================================
@@ -425,6 +432,50 @@
         return ui5Tree || {};
     }
 
+    // Merge the classic UI5 and Web Components application-info section maps
+    // for the App Info tab. On mixed pages both frameworks contribute sections;
+    // classic UI5 keeps its original top-level sections and the Web Components
+    // info arrives as a single self-labelled "UI5 Web Components" group (see
+    // webcMain.js _buildApplicationInfo), so the two read as distinct without
+    // any title rewriting and their keys never collide. Classic sections are
+    // inserted first so they render above the Web Components group. On
+    // single-framework pages the relevant map is returned unchanged.
+    function _getMergedApplicationInfo(frameId) {
+        var fd = frameData[frameId];
+        if (!fd) {
+            return {};
+        }
+        var ui5Info = fd.applicationInformationUI5;
+        var webcInfo = fd.applicationInformationWebC;
+
+        if (ui5Info && webcInfo) {
+            var merged = {};
+            var key;
+            for (key in ui5Info) {
+                merged[key] = ui5Info[key];
+            }
+            for (key in webcInfo) {
+                merged[key] = webcInfo[key];
+            }
+            return merged;
+        }
+
+        return webcInfo || ui5Info || {};
+    }
+
+    // Recompute the merged App Info map for a frame, cache it on frameData
+    // (used by displayFrameData and the AI chat context), and push it to the
+    // App Info tab when that frame is currently selected.
+    function _refreshAppInfo(frameId) {
+        var merged = _getMergedApplicationInfo(frameId);
+        if (frameData[frameId]) {
+            frameData[frameId].applicationInformation = merged;
+        }
+        if (framesSelect.getSelectedId() === frameId) {
+            appInfo.setData(merged);
+        }
+    }
+
     displayFrameData = function (options) {
         var frameId = options.selectedId;
         var oldFrameId = options.oldSelectedId;
@@ -436,7 +487,7 @@
         if (UI5Data) {
             controlTree.setData(_getMergedControlTree(frameId));
             UI5Data.selectedElementId && controlTree.setSelectedElement(UI5Data.selectedElementId);
-            appInfo.setData(UI5Data.applicationInformation);
+            appInfo.setData(_getMergedApplicationInfo(frameId));
             UI5Data.elementRegistry && oElementsRegistryMasterView.setData(UI5Data.elementRegistry);
 
             controlProperties.setData(UI5Data.controlProperties || {});
@@ -592,7 +643,7 @@
             var frameId = messageSender.frameId;
             frameData[frameId].controlTree = message.controlTree;
             frameData[frameId].controlTreeUI5 = message.controlTree;
-            frameData[frameId].applicationInformation = message.applicationInformation;
+            frameData[frameId].applicationInformationUI5 = message.applicationInformation;
             frameData[frameId].elementRegistry = message.elementRegistry;
 
             if (framesSelect.getSelectedId() === frameId) {
@@ -600,9 +651,12 @@
 
                 // Set URL for AI Chat history
                 aiChat.setUrl(frameData[frameId].url);
-                appInfo.setData(message.applicationInformation);
                 oElementsRegistryMasterView.setData(message.elementRegistry);
             }
+
+            // Merge with any Web Components info already collected for this
+            // frame and refresh the App Info tab (see _getMergedApplicationInfo).
+            _refreshAppInfo(frameId);
         },
 
         /**
@@ -802,23 +856,17 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
-            // Precedence rule for the App Info tab on mixed pages: classic UI5
-            // wins because it provides richer info (loaded libraries, modules,
-            // bootstrap config, URL parameters), whereas WebC only emits a
-            // minimal "General" section. We populate from WebC only when
-            // classic hasn't already filled this in.
-            if (!frameData[frameId].applicationInformation) {
-                frameData[frameId].applicationInformation = message.applicationInformation;
-            }
+            frameData[frameId].applicationInformationWebC = message.applicationInformation;
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
-                // Avoid overwriting the App Info tab if classic UI5 will
-                // populate it shortly (or already did) — same precedence rule.
-                if (!frameData[frameId].isUI5Detected) {
-                    appInfo.setData(frameData[frameId].applicationInformation);
-                }
             }
+
+            // On mixed pages the classic UI5 sections and the Web Components
+            // sections are shown together in the App Info tab; on pure-WebC
+            // pages only the WebC sections are present (see
+            // _getMergedApplicationInfo).
+            _refreshAppInfo(frameId);
         },
 
         'on-application-dom-update-webc': function (message, messageSender) {
@@ -827,10 +875,15 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
+            // Tag usage counts and the runtime list can change as the DOM
+            // mutates, so refresh the stored WebC app info too.
+            frameData[frameId].applicationInformationWebC = message.applicationInformation;
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
             }
+
+            _refreshAppInfo(frameId);
         },
 
         'on-ping-frames': function(message) {

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -172,6 +172,20 @@
         };
     }
 
+    // Escape HTML-significant characters. The DataView escapes string *values*
+    // but not section *titles* or *keys* (DataViewHelper._wrapInTag interpolates
+    // them raw). Any page-controlled string that ends up in a title/key — e.g. a
+    // runtime's alias or scoping suffix — must be escaped here first, otherwise a
+    // hostile page could inject markup into the DevTools panel.
+    function _escapeHTML(value) {
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     // Stringify a configuration value for display in the App Info tab.
     function _formatConfigValue(value) {
         if (value === null || value === undefined) {
@@ -187,20 +201,20 @@
         return value;
     }
 
-    // Build application info in the same shape as classic UI5's
-    // applicationUtils.getApplicationInfo(). Surfaces what the framework
-    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
-    // configuration (theme, language, timezone, ...), registered tags and
-    // features, and a list of runtimes when more than one is active on the
-    // page.
     // --- App Info section builders. Each returns a {options, data} section
     // or null if there's nothing to report. ---
 
-    function _generalSection(common) {
+    function _generalSection(common, runtimes) {
         var general = {};
         general[common.frameworkName] = common.version || '(unknown)';
-        if (common.description) {
-            general.Description = common.description;
+        general.Runtimes = runtimes.length;
+        // Interop is page-level; read it from the primary (first) runtime.
+        var primary = runtimes[0] || {};
+        if (typeof primary.openUI5Detected === 'boolean') {
+            general['OpenUI5 detected'] = primary.openUI5Detected;
+            if (typeof primary.openUI5LoadedFirst === 'boolean') {
+                general['OpenUI5 loaded first'] = primary.openUI5LoadedFirst;
+            }
         }
         general['User Agent'] = navigator.userAgent;
         general.Application = location.href;
@@ -231,11 +245,26 @@
         });
     }
 
-    function _registeredTagsSection(tags) {
-        if (!Array.isArray(tags) || !tags.length) {
+    // Tags with at least one live instance on the page. Object keys sort
+    // alphabetically in the DataView; the value is the instance count.
+    function _usedTagsSection(usedTags) {
+        if (!Array.isArray(usedTags) || !usedTags.length) {
             return null;
         }
-        return _section('Registered tags (' + tags.length + ')', _asSortedArray(tags), false);
+        var data = {};
+        for (var i = 0; i < usedTags.length; i++) {
+            data[usedTags[i].tag] = usedTags[i].count;
+        }
+        return _section('Tags in use (' + usedTags.length + ')', data);
+    }
+
+    // Registered tags that are not currently instantiated anywhere on the page.
+    function _unusedTagsSection(unusedTags) {
+        if (!Array.isArray(unusedTags) || !unusedTags.length) {
+            return null;
+        }
+        return _section('Tags registered, not in use (' + unusedTags.length + ')',
+            _asSortedArray(unusedTags), false);
     }
 
     function _registeredFeaturesSection(features) {
@@ -245,59 +274,96 @@
         return _section('Registered features (' + features.length + ')', _asSortedArray(features), false);
     }
 
-    function _interopSection(primary) {
-        if (typeof primary.openUI5Detected !== 'boolean') {
-            return null;
+    // Left-pad the runtime index so per-runtime section titles keep numeric
+    // order under the DataView's alphabetical key sort. Only widens once indices
+    // reach two digits (11+ runtimes); typical pages keep the bare "Runtime 0".
+    function _padIndex(index, total) {
+        var width = String(Math.max(total - 1, 0)).length;
+        var s = String(index);
+        while (s.length < width) {
+            s = '0' + s;
         }
-        var interop = {};
-        interop['OpenUI5 detected'] = primary.openUI5Detected;
-        if (typeof primary.openUI5LoadedFirst === 'boolean') {
-            interop['OpenUI5 loaded first'] = primary.openUI5LoadedFirst;
-        }
-        return _section('Interop', interop);
+        return s;
     }
 
-    function _runtimesSection(runtimes) {
-        if (runtimes.length <= 1) {
-            return null;
+    // A concise per-runtime label, e.g. "Runtime 0 — v2.19.0 (myapp)" or,
+    // when there's no alias, "Runtime 0 — v2.19.0 [scoping-suffix]". The
+    // version/alias/scoping-suffix are page-controlled and land in a section
+    // title, so escape them (the DataView does not escape titles).
+    function _runtimeLabel(rt, total) {
+        var label = 'Runtime ' + _padIndex(rt.index, total || 1) +
+            ' — v' + _escapeHTML(rt.version || 'unknown');
+        if (rt.alias) {
+            label += ' (' + _escapeHTML(rt.alias) + ')';
+        } else if (rt.scopingSuffix) {
+            label += ' [' + _escapeHTML(rt.scopingSuffix) + ']';
         }
-        var data = [];
-        for (var r = 0; r < runtimes.length; r++) {
-            var rt = runtimes[r];
-            data.push((rt.alias ? rt.alias + ' — ' : '') +
-                (rt.description || ('version ' + (rt.version || 'unknown'))));
-        }
-        return _section('Runtimes (' + runtimes.length + ')', data);
+        return label;
     }
 
-    // Build application info in the same shape as classic UI5's
-    // applicationUtils.getApplicationInfo(). Surfaces what the framework
-    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
-    // configuration (theme, language, timezone, ...), registered tags and
-    // features, and a list of runtimes when more than one is active on the
-    // page.
+    // One expandable section for a single runtime: its identity fields plus
+    // nested Configuration / tags-in-use / unused-tags / features sub-sections,
+    // each scoped to that runtime. Collapsed by default — a single runtime can
+    // register hundreds of tags.
+    function _runtimeDetailSection(rt, total) {
+        var data = { Version: rt.version || '(unknown)' };
+        if (rt.alias) {
+            data.Alias = rt.alias;
+        }
+        if (rt.scopingSuffix) {
+            data['Scoping suffix'] = rt.scopingSuffix;
+        }
+        if (rt.importMetaUrl) {
+            data['Runtime URL'] = rt.importMetaUrl;
+        }
+
+        var nested = [
+            _configurationSection(rt.configuration),
+            _usedTagsSection(rt.usedTags),
+            _unusedTagsSection(rt.unusedTags),
+            _registeredFeaturesSection(rt.registeredFeatures)
+        ];
+        for (var i = 0; i < nested.length; i++) {
+            if (nested[i]) {
+                data[nested[i].options.title] = nested[i];
+            }
+        }
+
+        return _section(_runtimeLabel(rt, total), data, false);
+    }
+
+    // Build the Application-Info payload for the App Info tab. Everything the
+    // framework exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts)
+    // is grouped under a single self-labelled "UI5 Web Components" section so it
+    // reads as distinct from the classic SAPUI5 sections on mixed pages. The
+    // group holds a General summary and one collapsible section per runtime (with
+    // that runtime's configuration, used/unused tags and features).
     function _buildApplicationInfo(frameworkInformation) {
         var common = frameworkInformation.commonInformation;
         var runtimes = (frameworkInformation.runtimes && frameworkInformation.runtimes.length) ?
             frameworkInformation.runtimes : [];
-        var primary = runtimes[0] || {};
-        var sections = {
-            common: _generalSection(common),
-            configuration: _configurationSection(primary.configuration),
-            registeredTags: _registeredTagsSection(primary.registeredTags),
-            registeredFeatures: _registeredFeaturesSection(primary.registeredFeatures),
-            interop: _interopSection(primary),
-            runtimes: _runtimesSection(runtimes)
-        };
 
-        var result = {};
-        var keys = Object.keys(sections);
-        for (var i = 0; i < keys.length; i++) {
-            if (sections[keys[i]]) {
-                result[keys[i]] = sections[keys[i]];
-            }
+        var groupData = { General: _generalSection(common, runtimes) };
+
+        for (var r = 0; r < runtimes.length; r++) {
+            var section = _runtimeDetailSection(runtimes[r], runtimes.length);
+            groupData[section.options.title] = section;
         }
-        return result;
+
+        var title = 'UI5 Web Components';
+        if (runtimes.length > 1) {
+            title += ' — ' + runtimes.length + ' runtimes (primary v' +
+                _escapeHTML(common.version || 'unknown') + ')';
+        } else if (common.version) {
+            title += ' (v' + _escapeHTML(common.version) + ')';
+        }
+
+        return {
+            webcRoot: {
+                options: { title: title, expandable: true, expanded: true },
+                data: groupData
+            }
+        };
     }
 
     // Send the current control tree to the panel

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -122,12 +122,13 @@
         return slotData.type === Node ? 'Node' : 'HTMLElement';
     }
 
-    // Returns the array of runtime descriptors the framework registers on the
-    // shared-resources meta element. See packages/base/src/Runtimes.ts.
-    // Each runtime exposes: version, alias, description, registeredTags,
+    // Returns the raw array of runtime descriptors the framework registers on
+    // the shared-resources meta element. See packages/base/src/Runtimes.ts.
+    // Each runtime exposes (mostly as live getters): version, alias,
+    // description, importMetaUrl, scopingSuffix, registeredTags,
     // registeredFeatures, configuration (theme, language, timezone, etc.),
-    // openUI5Detected, openUI5LoadedFirst, and more. Returns [] if the
-    // meta element or Runtimes property is missing.
+    // openUI5Detected, openUI5LoadedFirst. Returns [] if the meta element or
+    // Runtimes property is missing.
     function _getRuntimes() {
         try {
             var meta = document.querySelector('meta[name="ui5-shared-resources"]');
@@ -140,10 +141,106 @@
         return [];
     }
 
+    // Many runtime fields are live getters that call framework functions and
+    // can throw (e.g. on partially-booted runtimes). Read every field through
+    // this guard so one bad getter never breaks the whole App Info tab.
+    function _safe(fn, fallback) {
+        try {
+            var value = fn();
+            return value === undefined ? fallback : value;
+        } catch (e) {
+            return fallback;
+        }
+    }
+
+    // Count live UI5 web component instances per tag name, walking the whole
+    // document including shadow roots. Light-DOM-only queries miss components
+    // rendered inside other components' shadow roots, so we recurse. Returns a
+    // plain map { localName: count }.
+    function _getTagUsageCounts() {
+        var counts = Object.create(null);
+
+        function walk(root) {
+            var all = root.querySelectorAll('*');
+            for (var i = 0; i < all.length; i++) {
+                var el = all[i];
+                if (el.isUI5Element === true) {
+                    var tag = el.localName;
+                    counts[tag] = (counts[tag] || 0) + 1;
+                }
+                if (el.shadowRoot) {
+                    walk(el.shadowRoot);
+                }
+            }
+        }
+
+        walk(document);
+        return counts;
+    }
+
+    // Look up how many instances of a registered tag are on the page.
+    // `registeredTags` comes from getMetadata().getTag(), which already applies
+    // any scoping suffix (ui5-button-<suffix>), and the DOM elements carry that
+    // same scoped name — so usageCounts[tag] matches directly. The extra
+    // scoped-spelling lookup below is a defensive no-op for that case and only
+    // contributes if a framework version were to expose base (unscoped) tags.
+    // See packages/base/src/UI5ElementMetadata.ts (getTag) and
+    // packages/base/src/CustomElementsScopeUtils.ts.
+    function _usageForTag(usageCounts, tag, scopingSuffix) {
+        var count = usageCounts[tag] || 0;
+        if (scopingSuffix) {
+            count += usageCounts[tag + '-' + scopingSuffix] || 0;
+        }
+        return count;
+    }
+
+    // Normalize the raw runtime descriptors into plain, serializable objects
+    // (the panel receives these over postMessage, so no getters/functions can
+    // survive). Splits each runtime's registered tags into used/unused with
+    // instance counts.
+    function _normalizeRuntimes() {
+        var raw = _getRuntimes();
+        var usageCounts = _getTagUsageCounts();
+
+        return raw.map(function (rt, index) {
+            var scopingSuffix = _safe(function () { return rt.scopingSuffix; }, '');
+            var registeredTags = _safe(function () { return rt.registeredTags; }, []) || [];
+            var usedTags = [];
+            var unusedTags = [];
+
+            registeredTags.forEach(function (tag) {
+                var count = _usageForTag(usageCounts, tag, scopingSuffix);
+                if (count > 0) {
+                    usedTags.push({ tag: tag, count: count });
+                } else {
+                    unusedTags.push(tag);
+                }
+            });
+
+            return {
+                index: index,
+                version: _safe(function () { return rt.version; }, ''),
+                isNext: _safe(function () { return rt.isNext; }, false),
+                buildTime: _safe(function () { return rt.buildTime; }, undefined),
+                alias: _safe(function () { return rt.alias; }, ''),
+                description: _safe(function () { return rt.description; }, ''),
+                importMetaUrl: _safe(function () { return rt.importMetaUrl; }, ''),
+                scopingSuffix: scopingSuffix,
+                registeredTags: registeredTags,
+                usedTags: usedTags,
+                unusedTags: unusedTags,
+                registeredFeatures: _safe(function () { return rt.registeredFeatures; }, []) || [],
+                configuration: _safe(function () { return rt.configuration; }, null),
+                openUI5Detected: _safe(function () { return rt.openUI5Detected; }, undefined),
+                openUI5LoadedFirst: _safe(function () { return rt.openUI5LoadedFirst; }, undefined)
+            };
+        });
+    }
+
     window.__ui5WebComponentsToolsAPI = {
 
         getFrameworkInformation: function () {
-            var runtimes = _getRuntimes();
+            var runtimes = _normalizeRuntimes();
             var primary = runtimes[0] || {};
             return Promise.resolve({
                 commonInformation: {


### PR DESCRIPTION
Merge classic SAPUI5 and UI5 Web Components application info on mixed pages instead of letting one framework win. WebC info is emitted as a single self-labelled "UI5 Web Components" group with one collapsible section per runtime (version, alias, scoping suffix, configuration, used/unused tags and features), rendered alongside the classic sections.

Additional improvements:
- Drop the tag-conflict section: a runtime only records tags it wins, so diffing registeredTags across runtimes could never detect a collision.
- Escape page-controlled strings (version/alias/scoping suffix) that land in DataView section titles, which are not escaped by the DataView.
- Zero-pad runtime indices at 11+ runtimes so section titles keep numeric order under the DataView's alphabetical key sort.