### PR TITLE
feat(ai): add OpenAIProvider behind the registry

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -166,6 +166,7 @@
         "Event": true,
 		"ace": true,
 		"self": true,
-		"AbortController": true
+		"AbortController": true,
+		"AbortSignal": true
     }
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -28,7 +28,7 @@
         }
     ],
     "content_security_policy": {
-        "extension_pages": "default-src 'self'; img-src 'self' data:; style-src 'unsafe-inline';"
+        "extension_pages": "default-src 'self'; connect-src 'self' http: https:; img-src 'self' data:; style-src 'unsafe-inline';"
     },
     "description": "With the UI5 Inspector, you can easily debug and support your OpenUI5 or SAPUI5-based apps.",
     "devtools_page": "/html/devtools/index.html",

--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -4,6 +4,7 @@
     var utils = require('../modules/utils/utils.js');
     var ContextMenu = require('../modules/background/ContextMenu.js');
     var pageAction = require('../modules/background/pageAction.js');
+    var attachOpenAIHandler = require('../modules/background/openaiHandler.js');
 
     var contextMenu = new ContextMenu({
         title: 'Inspect UI5 element',
@@ -501,6 +502,8 @@
                         break;
                 }
             });
+        } else if (port.name === 'openai-api') {
+            attachOpenAIHandler(port);
         }
     });
 

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -41,6 +41,7 @@ function AssistantController({
     this._clearConsoleErrors = clearConsoleErrors;
 
     this._capabilityState = { status: 'unavailable', message: 'Checking model status...', progress: 0 };
+    this._lastReadyMessage = 'Ready';
     this._listeners = {};
     this._currentUrl = null;
     this._conversationMemory = [];
@@ -91,6 +92,9 @@ AssistantController.prototype._setCapabilityState = function (status, message, p
         message: message || '',
         progress: typeof progress === 'number' ? progress : 0
     };
+    if (status === 'ready' && message) {
+        this._lastReadyMessage = message;
+    }
     this._emit('capability-state-changed', this._capabilityState);
 };
 
@@ -161,7 +165,7 @@ AssistantController.prototype.sendUserMessage = function (userMessage) {
             this._conversationMemory.push({ role: 'assistant', content: fullText });
             this._isStreaming = false;
             if (this._capabilityState.status === 'streaming-failed') {
-                this._setCapabilityState('ready', 'Gemini Nano is ready', 0);
+                this._setCapabilityState('ready', this._lastReadyMessage, 0);
             }
             this._emit('stream-complete', { content: fullText });
             return { content: fullText };
@@ -203,7 +207,7 @@ AssistantController.prototype.setUrl = function (url) {
 
     return this._loadConversationMemory().then(() => {
         this._provider.destroy();
-        this._setCapabilityState('ready', 'Gemini Nano is ready', 0);
+        this._setCapabilityState('ready', this._lastReadyMessage, 0);
     });
 };
 
@@ -237,7 +241,7 @@ AssistantController.prototype.clearConversation = function () {
         this._provider.destroy();
         this._emit('conversation-cleared');
         if (this._capabilityState.status === 'ready') {
-            this._setCapabilityState('ready', 'Gemini Nano is ready', 0);
+            this._setCapabilityState('ready', this._lastReadyMessage, 0);
         }
     });
 };

--- a/app/scripts/modules/ai/OpenAIProvider.js
+++ b/app/scripts/modules/ai/OpenAIProvider.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * AI Provider backed by any OpenAI-compatible HTTP endpoint (real OpenAI, Ollama, LM Studio, Groq,
+ * etc.). Streams responses via SSE. All network I/O goes through `options.fetch`, defaulting to
+ * `window.fetch`, so tests can inject a fake at the constructor seam.
+ *
+ * @param {Object} config
+ * @param {string} config.baseUrl - e.g. `http://localhost:6655/openai/v1`. No trailing `/`.
+ * @param {string} config.apiKey  - Bearer token. Never included in error messages or logs.
+ * @param {string} config.model   - Model identifier passed to the API.
+ * @param {Function} [config.fetch] - Test seam. Defaults to the global `fetch`.
+ * @constructor
+ */
+function OpenAIProvider(config) {
+    const cfg = config || {};
+    this._baseUrl = cfg.baseUrl || '';
+    this._apiKey = cfg.apiKey || '';
+    this._model = cfg.model || '';
+    this._fetch = cfg.fetch || (typeof window !== 'undefined' && window.fetch ? window.fetch.bind(window) : null);
+    this._abortController = null;
+}
+
+const DONE = Symbol('sse-done');
+
+function abortError() {
+    const err = new Error('Aborted');
+    err.name = 'AbortError';
+    return err;
+}
+
+function extractErrorMessage(response) {
+    return response.json().then(
+        function (body) {
+            if (body && body.error && body.error.message) {
+                return body.error.message;
+            }
+            return 'HTTP ' + response.status;
+        },
+        function () {
+            return 'HTTP ' + response.status;
+        }
+    );
+}
+
+function parseSseEvent(event) {
+    const trimmed = event.trim();
+    if (!trimmed.startsWith('data:')) {
+        return '';
+    }
+    const payload = trimmed.slice(5).trim();
+    if (payload === '[DONE]') {
+        return DONE;
+    }
+    try {
+        const parsed = JSON.parse(payload);
+        const choices = parsed && parsed.choices;
+        if (!choices || !choices.length) {
+            return '';
+        }
+        const delta = choices[0].delta;
+        return (delta && typeof delta.content === 'string') ? delta.content : '';
+    } catch (e) {
+        return '';
+    }
+}
+
+function readSseStream(body, onChunk, signal) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    function pump() {
+        if (signal && signal.aborted) {
+            reader.cancel();
+            return Promise.reject(abortError());
+        }
+        return reader.read().then(function (result) {
+            if (result.done) {
+                return fullText;
+            }
+            buffer += decoder.decode(result.value, { stream: true });
+
+            let separatorIdx = buffer.indexOf('\n\n');
+            while (separatorIdx !== -1) {
+                const event = buffer.slice(0, separatorIdx);
+                buffer = buffer.slice(separatorIdx + 2);
+
+                const delta = parseSseEvent(event);
+                if (delta === DONE) {
+                    reader.cancel();
+                    return fullText;
+                }
+                if (delta) {
+                    fullText += delta;
+                    if (typeof onChunk === 'function') {
+                        onChunk(delta);
+                    }
+                }
+                separatorIdx = buffer.indexOf('\n\n');
+            }
+            return pump();
+        }, function (err) {
+            if (signal && signal.aborted) {
+                throw abortError();
+            }
+            throw err;
+        });
+    }
+
+    return pump();
+}
+
+/**
+ * Return `ready` iff `baseUrl`, `apiKey`, and `model` are all set. No network ping.
+ * @returns {Promise<{status: string, message: string}>}
+ */
+OpenAIProvider.prototype.checkAvailability = function () {
+    if (this._baseUrl && this._apiKey && this._model) {
+        return Promise.resolve({ status: 'ready', message: 'Ready' });
+    }
+    return Promise.resolve({ status: 'unavailable', message: 'not configured' });
+};
+
+/**
+ * POST `messages` to `${baseUrl}/chat/completions` with `stream: true`, parse the SSE response,
+ * forward content deltas via `onChunk`, and resolve with the accumulated full text.
+ *
+ * @param {Array<{role: string, content: string}>} messages
+ * @param {{onChunk?: Function, signal?: AbortSignal}} [options]
+ * @returns {Promise<string>}
+ */
+OpenAIProvider.prototype.sendMessage = function (messages, options) {
+    const opts = options || {};
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+        return Promise.reject(new Error('sendMessage: messages must be a non-empty array'));
+    }
+    if (opts.signal && opts.signal.aborted) {
+        return Promise.reject(abortError());
+    }
+
+    const internalController = new AbortController();
+    this._abortController = internalController;
+    const combinedSignal = opts.signal ?
+        AbortSignal.any([opts.signal, internalController.signal]) :
+        internalController.signal;
+
+    const url = this._baseUrl + '/chat/completions';
+    const body = JSON.stringify({
+        model: this._model,
+        messages: messages,
+        stream: true
+    });
+    const headers = {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + this._apiKey
+    };
+
+    return this._fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: body,
+        signal: combinedSignal
+    }).then(function (response) {
+        if (!response.ok) {
+            return extractErrorMessage(response).then(function (msg) {
+                throw new Error(msg);
+            });
+        }
+        return readSseStream(response.body, opts.onChunk, combinedSignal);
+    });
+};
+
+OpenAIProvider.prototype.destroy = function () {
+    if (this._abortController) {
+        this._abortController.abort();
+        this._abortController = null;
+    }
+};
+
+module.exports = OpenAIProvider;

--- a/app/scripts/modules/ai/OpenAIProvider.js
+++ b/app/scripts/modules/ai/OpenAIProvider.js
@@ -158,9 +158,23 @@ OpenAIProvider.prototype.sendMessage = function (messages, options) {
 };
 
 /**
+ * OpenAI-compatible endpoints expose no client-visible token quota, so there is no usage to
+ * report. Returning `null` tells the UI to leave the token pill untouched (see AIChat).
+ * @returns {Promise<null>}
+ */
+OpenAIProvider.prototype.getUsageInfo = function () {
+    return Promise.resolve(null);
+};
+
+/**
  * Cancel any in-flight request and disconnect the port.
  */
 OpenAIProvider.prototype.destroy = function () {
+    if (this._disconnectHandler) {
+        const h = this._disconnectHandler;
+        this._disconnectHandler = null;
+        h();
+    }
     if (this._isConnected && this._port) {
         this._port.postMessage({ type: 'cancel' });
         this._port.disconnect();

--- a/app/scripts/modules/ai/OpenAIProvider.js
+++ b/app/scripts/modules/ai/OpenAIProvider.js
@@ -1,15 +1,15 @@
 'use strict';
 
 /**
- * AI Provider backed by any OpenAI-compatible HTTP endpoint (real OpenAI, Ollama, LM Studio, Groq,
- * etc.). Streams responses via SSE. All network I/O goes through `options.fetch`, defaulting to
- * `window.fetch`, so tests can inject a fake at the constructor seam.
+ * AI Provider backed by any OpenAI-compatible HTTP endpoint. Wraps the background service worker's
+ * `openai-api` port protocol — the panel's CSP blocks cross-origin `fetch`, so all network I/O
+ * runs in the service worker (see modules/background/openaiHandler.js).
  *
  * @param {Object} config
  * @param {string} config.baseUrl - e.g. `http://localhost:6655/openai/v1`. No trailing `/`.
  * @param {string} config.apiKey  - Bearer token. Never included in error messages or logs.
  * @param {string} config.model   - Model identifier passed to the API.
- * @param {Function} [config.fetch] - Test seam. Defaults to the global `fetch`.
+ * @param {Function} [config.portFactory] - Test seam. Defaults to a `chrome.runtime.connect` call.
  * @constructor
  */
 function OpenAIProvider(config) {
@@ -17,11 +17,14 @@ function OpenAIProvider(config) {
     this._baseUrl = cfg.baseUrl || '';
     this._apiKey = cfg.apiKey || '';
     this._model = cfg.model || '';
-    this._fetch = cfg.fetch || (typeof window !== 'undefined' && window.fetch ? window.fetch.bind(window) : null);
-    this._abortController = null;
+    this._portFactory = cfg.portFactory || function () {
+        return chrome.runtime.connect({ name: 'openai-api' });
+    };
+    this._port = null;
+    this._isConnected = false;
+    this._messageHandlers = {};
+    this._disconnectHandler = null;
 }
-
-const DONE = Symbol('sse-done');
 
 function abortError() {
     const err = new Error('Aborted');
@@ -29,91 +32,35 @@ function abortError() {
     return err;
 }
 
-function extractErrorMessage(response) {
-    return response.json().then(
-        function (body) {
-            if (body && body.error && body.error.message) {
-                return body.error.message;
-            }
-            return 'HTTP ' + response.status;
-        },
-        function () {
-            return 'HTTP ' + response.status;
+OpenAIProvider.prototype._connect = function () {
+    if (this._isConnected) {
+        return;
+    }
+
+    this._port = this._portFactory();
+    this._isConnected = true;
+
+    this._port.onMessage.addListener((message) => {
+        const handler = this._messageHandlers[message.type];
+        if (handler) {
+            handler(message);
         }
-    );
-}
+    });
 
-function parseSseEvent(event) {
-    const trimmed = event.trim();
-    if (!trimmed.startsWith('data:')) {
-        return '';
-    }
-    const payload = trimmed.slice(5).trim();
-    if (payload === '[DONE]') {
-        return DONE;
-    }
-    try {
-        const parsed = JSON.parse(payload);
-        const choices = parsed && parsed.choices;
-        if (!choices || !choices.length) {
-            return '';
+    this._port.onDisconnect.addListener(() => {
+        this._isConnected = false;
+        this._port = null;
+
+        if (this._disconnectHandler) {
+            const h = this._disconnectHandler;
+            this._disconnectHandler = null;
+            h();
         }
-        const delta = choices[0].delta;
-        return (delta && typeof delta.content === 'string') ? delta.content : '';
-    } catch (e) {
-        return '';
-    }
-}
-
-function readSseStream(body, onChunk, signal) {
-    const reader = body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-    let fullText = '';
-
-    function pump() {
-        if (signal && signal.aborted) {
-            reader.cancel();
-            return Promise.reject(abortError());
-        }
-        return reader.read().then(function (result) {
-            if (result.done) {
-                return fullText;
-            }
-            buffer += decoder.decode(result.value, { stream: true });
-
-            let separatorIdx = buffer.indexOf('\n\n');
-            while (separatorIdx !== -1) {
-                const event = buffer.slice(0, separatorIdx);
-                buffer = buffer.slice(separatorIdx + 2);
-
-                const delta = parseSseEvent(event);
-                if (delta === DONE) {
-                    reader.cancel();
-                    return fullText;
-                }
-                if (delta) {
-                    fullText += delta;
-                    if (typeof onChunk === 'function') {
-                        onChunk(delta);
-                    }
-                }
-                separatorIdx = buffer.indexOf('\n\n');
-            }
-            return pump();
-        }, function (err) {
-            if (signal && signal.aborted) {
-                throw abortError();
-            }
-            throw err;
-        });
-    }
-
-    return pump();
-}
+    });
+};
 
 /**
- * Return `ready` iff `baseUrl`, `apiKey`, and `model` are all set. No network ping.
+ * Return `ready` iff `baseUrl`, `apiKey`, and `model` are all set. Local check — no port traffic.
  * @returns {Promise<{status: string, message: string}>}
  */
 OpenAIProvider.prototype.checkAvailability = function () {
@@ -124,8 +71,8 @@ OpenAIProvider.prototype.checkAvailability = function () {
 };
 
 /**
- * POST `messages` to `${baseUrl}/chat/completions` with `stream: true`, parse the SSE response,
- * forward content deltas via `onChunk`, and resolve with the accumulated full text.
+ * Post the messages to the background over the `openai-api` port. Route incoming
+ * `chunk`/`complete`/`error` frames. Resolve with the accumulated text on `complete`.
  *
  * @param {Array<{role: string, content: string}>} messages
  * @param {{onChunk?: Function, signal?: AbortSignal}} [options]
@@ -141,43 +88,87 @@ OpenAIProvider.prototype.sendMessage = function (messages, options) {
         return Promise.reject(abortError());
     }
 
-    const internalController = new AbortController();
-    this._abortController = internalController;
-    const combinedSignal = opts.signal ?
-        AbortSignal.any([opts.signal, internalController.signal]) :
-        internalController.signal;
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        let fullText = '';
+        let abortListener = null;
 
-    const url = this._baseUrl + '/chat/completions';
-    const body = JSON.stringify({
-        model: this._model,
-        messages: messages,
-        stream: true
-    });
-    const headers = {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + this._apiKey
-    };
+        const cleanup = () => {
+            delete this._messageHandlers.chunk;
+            delete this._messageHandlers.complete;
+            delete this._messageHandlers.error;
+            this._disconnectHandler = null;
+            if (opts.signal && abortListener) {
+                opts.signal.removeEventListener('abort', abortListener);
+            }
+        };
 
-    return this._fetch(url, {
-        method: 'POST',
-        headers: headers,
-        body: body,
-        signal: combinedSignal
-    }).then(function (response) {
-        if (!response.ok) {
-            return extractErrorMessage(response).then(function (msg) {
-                throw new Error(msg);
-            });
+        const settle = (fn) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cleanup();
+            fn();
+        };
+
+        this._messageHandlers.chunk = (message) => {
+            if (settled) {
+                return;
+            }
+            fullText += message.content;
+            if (typeof opts.onChunk === 'function') {
+                opts.onChunk(message.content);
+            }
+        };
+
+        this._messageHandlers.complete = () => {
+            settle(() => resolve(fullText));
+        };
+
+        this._messageHandlers.error = (message) => {
+            settle(() => reject(new Error(message.message)));
+        };
+
+        this._disconnectHandler = () => {
+            settle(() => reject(new Error('Connection to background script lost. Please try again.')));
+        };
+
+        if (opts.signal) {
+            abortListener = () => {
+                if (this._isConnected) {
+                    this._port.postMessage({ type: 'cancel' });
+                }
+                settle(() => reject(abortError()));
+            };
+            opts.signal.addEventListener('abort', abortListener);
         }
-        return readSseStream(response.body, opts.onChunk, combinedSignal);
+
+        this._connect();
+        this._port.postMessage({
+            type: 'send',
+            config: {
+                baseUrl: this._baseUrl,
+                apiKey: this._apiKey,
+                model: this._model
+            },
+            messages: messages
+        });
     });
 };
 
+/**
+ * Cancel any in-flight request and disconnect the port.
+ */
 OpenAIProvider.prototype.destroy = function () {
-    if (this._abortController) {
-        this._abortController.abort();
-        this._abortController = null;
+    if (this._isConnected && this._port) {
+        this._port.postMessage({ type: 'cancel' });
+        this._port.disconnect();
     }
+    this._port = null;
+    this._isConnected = false;
+    this._messageHandlers = {};
+    this._disconnectHandler = null;
 };
 
 module.exports = OpenAIProvider;

--- a/app/scripts/modules/ai/OpenAIProvider.js
+++ b/app/scripts/modules/ai/OpenAIProvider.js
@@ -65,7 +65,7 @@ OpenAIProvider.prototype._connect = function () {
  */
 OpenAIProvider.prototype.checkAvailability = function () {
     if (this._baseUrl && this._apiKey && this._model) {
-        return Promise.resolve({ status: 'ready', message: 'Ready' });
+        return Promise.resolve({ status: 'ready', message: 'OpenAI-compatible (' + this._model + ') ready' });
     }
     return Promise.resolve({ status: 'unavailable', message: 'not configured' });
 };

--- a/app/scripts/modules/ai/providers/index.js
+++ b/app/scripts/modules/ai/providers/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const GeminiNanoProvider = require('../GeminiNanoProvider.js');
+const OpenAIProvider = require('../OpenAIProvider.js');
 
 /**
  * Static registry of AI providers available to the assistant. Keys are provider names persisted in
@@ -16,6 +17,15 @@ const PROVIDERS = {
         displayName: 'Gemini Nano (on-device)',
         ProviderClass: GeminiNanoProvider,
         configSchema: []
+    },
+    'openai': {
+        displayName: 'OpenAI-compatible',
+        ProviderClass: OpenAIProvider,
+        configSchema: [
+            { key: 'baseUrl', label: 'Base URL', type: 'text', required: true },
+            { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+            { key: 'model', label: 'Model', type: 'text', required: true }
+        ]
     }
 };
 

--- a/app/scripts/modules/background/openaiHandler.js
+++ b/app/scripts/modules/background/openaiHandler.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const DONE = 'sse:done';
+
+function redact(text, apiKey) {
+    if (!apiKey || typeof text !== 'string') {
+        return text;
+    }
+    return text.split(apiKey).join('[redacted]');
+}
+
+function parseSseEvent(event) {
+    const trimmed = event.trim();
+    if (!trimmed.startsWith('data:')) {
+        return '';
+    }
+    const payload = trimmed.slice(5).trim();
+    if (payload === '[DONE]') {
+        return DONE;
+    }
+    try {
+        const parsed = JSON.parse(payload);
+        const choices = parsed && parsed.choices;
+        if (!choices || !choices.length) {
+            return '';
+        }
+        const delta = choices[0].delta;
+        return (delta && typeof delta.content === 'string') ? delta.content : '';
+    } catch (e) {
+        return '';
+    }
+}
+
+function extractErrorMessage(response, apiKey) {
+    return response.json().then(
+        function (body) {
+            if (body && body.error && body.error.message) {
+                return redact(body.error.message, apiKey);
+            }
+            return 'HTTP ' + response.status;
+        },
+        function () {
+            return 'HTTP ' + response.status;
+        }
+    );
+}
+
+function readSseStream(body, port, signal) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    function pump() {
+        if (signal.aborted) {
+            reader.cancel();
+            return;
+        }
+        return reader.read().then(function (result) {
+            if (signal.aborted) {
+                return;
+            }
+            if (result.done) {
+                port.postMessage({ type: 'complete' });
+                return;
+            }
+            buffer += decoder.decode(result.value, { stream: true });
+
+            let separatorIdx = buffer.indexOf('\n\n');
+            while (separatorIdx !== -1) {
+                const event = buffer.slice(0, separatorIdx);
+                buffer = buffer.slice(separatorIdx + 2);
+
+                const delta = parseSseEvent(event);
+                if (delta === DONE) {
+                    reader.cancel();
+                    port.postMessage({ type: 'complete' });
+                    return;
+                }
+                if (delta) {
+                    port.postMessage({ type: 'chunk', content: delta });
+                }
+                separatorIdx = buffer.indexOf('\n\n');
+            }
+            return pump();
+        }, function (err) {
+            if (signal.aborted) {
+                return;
+            }
+            port.postMessage({ type: 'error', message: err && err.message ? err.message : 'Stream error' });
+        });
+    }
+
+    return pump();
+}
+
+/**
+ * Background-side handler for the `openai-api` port. Handles one port instance: on `send`, kicks
+ * off a `fetch` to `${baseUrl}/chat/completions`, parses the SSE response, and streams
+ * `chunk`/`complete`/`error` messages back over the port. On `cancel` (or port disconnect), aborts
+ * the in-flight fetch.
+ *
+ * The panel-side `OpenAIProvider` runs under a strict CSP (`default-src 'self'`) that blocks
+ * cross-origin fetch. The background service worker has broad `host_permissions` and no such CSP,
+ * so the network I/O lives here.
+ *
+ * @param {chrome.runtime.Port} port
+ * @param {{fetch?: Function}} [options] - Test seam for `fetch`. Defaults to the global `fetch`.
+ */
+function attachOpenAIHandler(port, options) {
+    const opts = options || {};
+    const fetchImpl = opts.fetch || (typeof fetch !== 'undefined' ? fetch : null);
+
+    let controller = null;
+
+    function handleSend(message) {
+        if (controller) {
+            controller.abort();
+        }
+        controller = new AbortController();
+        const signal = controller.signal;
+
+        const config = message.config || {};
+        const url = config.baseUrl + '/chat/completions';
+        const body = JSON.stringify({
+            model: config.model,
+            messages: message.messages,
+            stream: true
+        });
+        const headers = {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer ' + config.apiKey
+        };
+
+        fetchImpl(url, { method: 'POST', headers: headers, body: body, signal: signal }).then(
+            function (response) {
+                if (signal.aborted) {
+                    return;
+                }
+                if (!response.ok) {
+                    return extractErrorMessage(response, config.apiKey).then(function (msg) {
+                        if (!signal.aborted) {
+                            port.postMessage({ type: 'error', message: msg });
+                        }
+                    });
+                }
+                return readSseStream(response.body, port, signal);
+            },
+            function (err) {
+                if (signal.aborted) {
+                    return;
+                }
+                const raw = err && err.message ? err.message : 'Network error';
+                port.postMessage({ type: 'error', message: redact(raw, config.apiKey) });
+            }
+        );
+    }
+
+    port.onMessage.addListener(function (message) {
+        if (message.type === 'send') {
+            handleSend(message);
+        } else if (message.type === 'cancel') {
+            if (controller) {
+                controller.abort();
+                controller = null;
+            }
+        }
+    });
+
+    port.onDisconnect.addListener(function () {
+        if (controller) {
+            controller.abort();
+            controller = null;
+        }
+    });
+}
+
+module.exports = attachOpenAIHandler;

--- a/app/scripts/modules/background/openaiHandler.js
+++ b/app/scripts/modules/background/openaiHandler.js
@@ -175,3 +175,5 @@ function attachOpenAIHandler(port, options) {
 }
 
 module.exports = attachOpenAIHandler;
+module.exports.parseSseEvent = parseSseEvent;
+module.exports.DONE = DONE;

--- a/tests/modules/ai/AssistantController.spec.js
+++ b/tests/modules/ai/AssistantController.spec.js
@@ -1040,6 +1040,35 @@ describe('AssistantController', function () {
                 });
             });
         });
+
+        it('should re-emit the provider\'s own ready message (not a hard-coded string) after setUrl, so the banner reflects the active provider — a non-Gemini provider is not mislabelled as Gemini', function () {
+            const harness = createController();
+            harness.provider.availabilityResult = { status: 'ready', message: 'OpenAI-compatible (gpt-4o-mini) is ready' };
+            harness.controller.setUrl('https://example.com');
+            return harness.controller.initialize().then(function () {
+                const stateCountBeforeSwitch = harness.capabilityStates.length;
+                return harness.controller.setUrl('https://other.example.com').then(function () {
+                    const newStates = harness.capabilityStates.slice(stateCountBeforeSwitch);
+                    newStates.should.have.length(1);
+                    newStates[0].status.should.equal('ready');
+                    newStates[0].message.should.equal('OpenAI-compatible (gpt-4o-mini) is ready');
+                });
+            });
+        });
+
+        it('should re-emit the provider\'s own ready message (not a hard-coded string) after clearConversation, so the banner is not clobbered with a Gemini-specific label on a different provider', function () {
+            const harness = createController();
+            harness.provider.availabilityResult = { status: 'ready', message: 'OpenAI-compatible ready' };
+            harness.controller.setUrl('https://example.com');
+            return harness.controller.initialize().then(function () {
+                const stateCountBeforeClear = harness.capabilityStates.length;
+                return harness.controller.clearConversation().then(function () {
+                    const newStates = harness.capabilityStates.slice(stateCountBeforeClear);
+                    newStates.should.have.length(1);
+                    newStates[0].message.should.equal('OpenAI-compatible ready');
+                });
+            });
+        });
     });
 
     describe('idle-killed session recovery (provider-internal)', function () {

--- a/tests/modules/ai/OpenAIProvider.spec.js
+++ b/tests/modules/ai/OpenAIProvider.spec.js
@@ -2,63 +2,45 @@
 
 const OpenAIProvider = require('../../../app/scripts/modules/ai/OpenAIProvider.js');
 
-function sseEvent(data) {
-    return 'data: ' + JSON.stringify(data) + '\n\n';
-}
+function createFakePort() {
+    const messageListeners = [];
+    const disconnectListeners = [];
 
-function contentEvent(text) {
-    return sseEvent({ choices: [{ delta: { content: text } }] });
-}
-
-function createResponse({ ok = true, status = 200, chunks = [], errorBody = null } = {}) {
-    let cursor = 0;
-    const encoder = new TextEncoder();
-
-    const body = {
-        getReader: function () {
-            return {
-                read: function () {
-                    if (cursor >= chunks.length) {
-                        return Promise.resolve({ done: true, value: undefined });
-                    }
-                    const chunk = chunks[cursor++];
-                    return Promise.resolve({
-                        done: false,
-                        value: typeof chunk === 'string' ? encoder.encode(chunk) : chunk
-                    });
-                },
-                cancel: function () {
-                    cursor = chunks.length;
-                    return Promise.resolve();
-                }
-            };
-        }
+    const port = {
+        postMessage: function (message) {
+            port.posted.push(message);
+        },
+        onMessage: {
+            addListener: function (listener) {
+                messageListeners.push(listener);
+            }
+        },
+        onDisconnect: {
+            addListener: function (listener) {
+                disconnectListeners.push(listener);
+            }
+        },
+        disconnect: function () {
+            port.disconnected = true;
+        },
+        posted: [],
+        disconnected: false
     };
 
     return {
-        ok: ok,
-        status: status,
-        body: body,
-        json: function () {
-            return Promise.resolve(errorBody || {});
+        port: port,
+        posted: port.posted,
+        emit: function (message) {
+            messageListeners.forEach(function (listener) {
+                listener(message);
+            });
         },
-        text: function () {
-            return Promise.resolve(errorBody ? JSON.stringify(errorBody) : '');
+        triggerDisconnect: function () {
+            disconnectListeners.forEach(function (listener) {
+                listener();
+            });
         }
     };
-}
-
-function createFakeFetch(response) {
-    const calls = [];
-    const fetch = function (url, options) {
-        calls.push({ url: url, options: options });
-        if (typeof response === 'function') {
-            return Promise.resolve(response({ url: url, options: options }));
-        }
-        return Promise.resolve(response);
-    };
-    fetch.calls = calls;
-    return fetch;
 }
 
 function defaultConfig(overrides) {
@@ -69,17 +51,25 @@ function defaultConfig(overrides) {
     }, overrides || {});
 }
 
+function createProvider(configOverrides) {
+    const fake = createFakePort();
+    const provider = new OpenAIProvider(Object.assign(defaultConfig(configOverrides), {
+        portFactory: function () { return fake.port; }
+    }));
+    return { provider: provider, fake: fake };
+}
+
 describe('OpenAIProvider', function () {
     describe('#checkAvailability()', function () {
         it('should return `ready` when baseUrl, apiKey, and model are all present', function () {
-            const provider = new OpenAIProvider(defaultConfig());
+            const { provider } = createProvider();
             return provider.checkAvailability().then(function (result) {
                 result.status.should.equal('ready');
             });
         });
 
         it('should return `unavailable` when baseUrl is missing', function () {
-            const provider = new OpenAIProvider(defaultConfig({ baseUrl: '' }));
+            const { provider } = createProvider({ baseUrl: '' });
             return provider.checkAvailability().then(function (result) {
                 result.status.should.equal('unavailable');
                 result.message.should.contain('not configured');
@@ -87,342 +77,209 @@ describe('OpenAIProvider', function () {
         });
 
         it('should return `unavailable` when apiKey is missing', function () {
-            const provider = new OpenAIProvider(defaultConfig({ apiKey: '' }));
+            const { provider } = createProvider({ apiKey: '' });
             return provider.checkAvailability().then(function (result) {
                 result.status.should.equal('unavailable');
             });
         });
 
         it('should return `unavailable` when model is missing', function () {
-            const provider = new OpenAIProvider(defaultConfig({ model: '' }));
+            const { provider } = createProvider({ model: '' });
             return provider.checkAvailability().then(function (result) {
                 result.status.should.equal('unavailable');
             });
         });
 
-        it('should not make any network request', function () {
-            const fetch = createFakeFetch(createResponse());
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+        it('should not post anything on the port', function () {
+            const { provider, fake } = createProvider();
             return provider.checkAvailability().then(function () {
-                fetch.calls.length.should.equal(0);
+                fake.posted.should.have.length(0);
             });
         });
     });
 
-    describe('#sendMessage() — request wiring', function () {
-        it('should POST to `${baseUrl}/chat/completions` with the messages, model, and stream:true', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [contentEvent('hi'), 'data: [DONE]\n\n']
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+    describe('#sendMessage() — port protocol', function () {
+        it('should reject when the messages array is empty', function () {
+            const { provider } = createProvider();
+            return provider.sendMessage([]).then(function () {
+                throw new Error('Expected sendMessage to reject');
+            }, function (err) {
+                err.message.should.contain('non-empty');
+            });
+        });
+
+        it('should reject with AbortError when the signal is already aborted', function () {
+            const { provider } = createProvider();
+            const controller = new AbortController();
+            controller.abort();
+            return provider.sendMessage([
+                { role: 'user', content: 'Hi' }
+            ], { signal: controller.signal }).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.name.should.equal('AbortError');
+            });
+        });
+
+        it('should post {type:send, config, messages} on the port carrying baseUrl, apiKey, and model', async function () {
+            const { provider, fake } = createProvider();
             const messages = [
                 { role: 'system', content: 'You are helpful.' },
                 { role: 'user', content: 'Hello' }
             ];
-            return provider.sendMessage(messages).then(function () {
-                fetch.calls.length.should.equal(1);
-                fetch.calls[0].url.should.equal('http://localhost:6655/openai/v1/chat/completions');
-                fetch.calls[0].options.method.should.equal('POST');
-                const body = JSON.parse(fetch.calls[0].options.body);
-                body.model.should.equal('gpt-5.4');
-                body.stream.should.equal(true);
-                body.messages.should.deep.equal(messages);
+
+            const sendPromise = provider.sendMessage(messages);
+            await Promise.resolve();
+
+            fake.posted.should.have.length(1);
+            const posted = fake.posted[0];
+            posted.type.should.equal('send');
+            posted.messages.should.deep.equal(messages);
+            posted.config.should.deep.equal({
+                baseUrl: 'http://localhost:6655/openai/v1',
+                apiKey: 'secret-key',
+                model: 'gpt-5.4'
             });
+
+            fake.emit({ type: 'chunk', content: 'x' });
+            fake.emit({ type: 'complete' });
+            await sendPromise;
         });
 
-        it('should include a Bearer Authorization header with the API key', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [contentEvent('hi'), 'data: [DONE]\n\n']
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
-                const headers = fetch.calls[0].options.headers;
-                headers.Authorization.should.equal('Bearer secret-key');
-                headers['Content-Type'].should.equal('application/json');
-            });
-        });
-    });
-
-    describe('#sendMessage() — SSE parsing', function () {
-        it('should accumulate content deltas across chunks and resolve with the full text', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [
-                    contentEvent('Hello, '),
-                    contentEvent('world'),
-                    contentEvent('!'),
-                    'data: [DONE]\n\n'
-                ]
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+        it('should forward chunk messages via onChunk and resolve with the accumulated text on complete', async function () {
+            const { provider, fake } = createProvider();
             const received = [];
-            return provider.sendMessage(
+            const sendPromise = provider.sendMessage(
                 [{ role: 'user', content: 'Hi' }],
                 { onChunk: function (t) { received.push(t); } }
-            ).then(function (fullText) {
-                received.should.deep.equal(['Hello, ', 'world', '!']);
-                fullText.should.equal('Hello, world!');
-            });
+            );
+
+            await Promise.resolve();
+            fake.emit({ type: 'chunk', content: 'Hello, ' });
+            fake.emit({ type: 'chunk', content: 'world' });
+            fake.emit({ type: 'chunk', content: '!' });
+            fake.emit({ type: 'complete' });
+
+            const full = await sendPromise;
+            full.should.equal('Hello, world!');
+            received.should.deep.equal(['Hello, ', 'world', '!']);
         });
 
-        it('should buffer partial lines split across reads', function () {
-            const event = contentEvent('streamed');
-            const midpoint = Math.floor(event.length / 2);
-            const fetch = createFakeFetch(createResponse({
-                chunks: [
-                    event.slice(0, midpoint),
-                    event.slice(midpoint),
-                    'data: [DONE]\n\n'
-                ]
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }]
-            ).then(function (fullText) {
-                fullText.should.equal('streamed');
-            });
-        });
+        it('should reject with the transport-supplied message when an error frame arrives', async function () {
+            const { provider, fake } = createProvider();
+            const sendPromise = provider.sendMessage([{ role: 'user', content: 'Hi' }]);
 
-        it('should handle multiple SSE events packed in one read', function () {
-            const packed = contentEvent('one') + contentEvent('two') + contentEvent('three') + 'data: [DONE]\n\n';
-            const fetch = createFakeFetch(createResponse({ chunks: [packed] }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }]
-            ).then(function (fullText) {
-                fullText.should.equal('onetwothree');
-            });
-        });
+            await Promise.resolve();
+            fake.emit({ type: 'error', message: 'Invalid API key' });
 
-        it('should ignore SSE events whose delta has no content field (e.g. role-only opener)', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [
-                    sseEvent({ choices: [{ delta: { role: 'assistant' } }] }),
-                    contentEvent('body'),
-                    'data: [DONE]\n\n'
-                ]
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }]
-            ).then(function (fullText) {
-                fullText.should.equal('body');
-            });
-        });
-
-        it('should stop cleanly at the [DONE] sentinel without treating it as JSON', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [contentEvent('done-test'), 'data: [DONE]\n\n', contentEvent('after')]
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }]
-            ).then(function (fullText) {
-                fullText.should.equal('done-test');
-            });
-        });
-    });
-
-    describe('#sendMessage() — error surfacing', function () {
-        it('should reject with the API error message on 401', function () {
-            const fetch = createFakeFetch(createResponse({
-                ok: false,
-                status: 401,
-                errorBody: { error: { message: 'Invalid API key' } }
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+            try {
+                await sendPromise;
                 throw new Error('Expected reject');
-            }, function (err) {
-                err.message.should.contain('Invalid API key');
-            });
+            } catch (err) {
+                err.message.should.equal('Invalid API key');
+            }
         });
 
-        it('should reject with the API error message on 404', function () {
-            const fetch = createFakeFetch(createResponse({
-                ok: false,
-                status: 404,
-                errorBody: { error: { message: 'Model not found' } }
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
-                throw new Error('Expected reject');
-            }, function (err) {
-                err.message.should.contain('Model not found');
-            });
-        });
+        it('should reject when the port disconnects mid-request', async function () {
+            const { provider, fake } = createProvider();
+            const sendPromise = provider.sendMessage([{ role: 'user', content: 'Hi' }]);
 
-        it('should reject with the API error message on 429', function () {
-            const fetch = createFakeFetch(createResponse({
-                ok: false,
-                status: 429,
-                errorBody: { error: { message: 'Rate limited' } }
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
-                throw new Error('Expected reject');
-            }, function (err) {
-                err.message.should.contain('Rate limited');
-            });
-        });
+            await Promise.resolve();
+            fake.triggerDisconnect();
 
-        it('should never include the API key in error messages', function () {
-            const fetch = createFakeFetch(createResponse({
-                ok: false,
-                status: 401,
-                errorBody: { error: { message: 'Bad auth' } }
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig({ apiKey: 'super-secret-abc123' }), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+            try {
+                await sendPromise;
                 throw new Error('Expected reject');
-            }, function (err) {
-                err.message.should.not.contain('super-secret-abc123');
-            });
-        });
-
-        it('should reject with a generic status message when the API body is not parseable', function () {
-            const fetch = function () {
-                return Promise.resolve({
-                    ok: false,
-                    status: 500,
-                    body: null,
-                    json: function () { return Promise.reject(new Error('bad json')); },
-                    text: function () { return Promise.resolve(''); }
-                });
-            };
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
-                throw new Error('Expected reject');
-            }, function (err) {
-                err.message.should.contain('500');
-            });
+            } catch (err) {
+                err.message.should.contain('Connection');
+            }
         });
     });
 
     describe('#sendMessage() — cancellation', function () {
-        it('should reject with an AbortError when the signal is already aborted', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [contentEvent('x'), 'data: [DONE]\n\n']
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+        it('should post {type:cancel} and reject with AbortError when the signal aborts mid-stream', async function () {
+            const { provider, fake } = createProvider();
             const controller = new AbortController();
+
+            const sendPromise = provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }],
+                { signal: controller.signal }
+            );
+
+            await Promise.resolve();
+            fake.emit({ type: 'chunk', content: 'partial' });
             controller.abort();
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }],
-                { signal: controller.signal }
-            ).then(function () {
+
+            try {
+                await sendPromise;
                 throw new Error('Expected reject');
-            }, function (err) {
+            } catch (err) {
                 err.name.should.equal('AbortError');
-            });
+            }
+
+            const cancelPosts = fake.posted.filter(function (m) { return m.type === 'cancel'; });
+            cancelPosts.should.have.length(1);
         });
 
-        it('should forward caller-signal aborts to the fetch call', function () {
-            const fetch = createFakeFetch(createResponse({
-                chunks: [contentEvent('x'), 'data: [DONE]\n\n']
-            }));
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+        it('should ignore chunks that arrive after the signal aborts', async function () {
+            const { provider, fake } = createProvider();
             const controller = new AbortController();
-            return provider.sendMessage(
+            const received = [];
+
+            const sendPromise = provider.sendMessage(
                 [{ role: 'user', content: 'Hi' }],
-                { signal: controller.signal }
-            ).then(function () {
-                const fetchSignal = fetch.calls[0].options.signal;
-                (typeof fetchSignal === 'object').should.equal(true);
-                (fetchSignal.aborted === false).should.equal(true);
-                controller.abort();
-                (fetchSignal.aborted === true).should.equal(true);
-            });
-        });
-
-        it('should reject with AbortError when the signal aborts mid-stream', function () {
-            const controller = new AbortController();
-            let readCount = 0;
-            const encoder = new TextEncoder();
-
-            const response = {
-                ok: true,
-                status: 200,
-                body: {
-                    getReader: function () {
-                        return {
-                            read: function () {
-                                readCount++;
-                                if (readCount === 1) {
-                                    return Promise.resolve({
-                                        done: false,
-                                        value: encoder.encode(contentEvent('first'))
-                                    });
-                                }
-                                controller.abort();
-                                const err = new Error('Aborted');
-                                err.name = 'AbortError';
-                                return Promise.reject(err);
-                            },
-                            cancel: function () {
-                                return Promise.resolve();
-                            }
-                        };
-                    }
+                {
+                    onChunk: function (t) { received.push(t); },
+                    signal: controller.signal
                 }
-            };
+            );
 
-            const fetch = createFakeFetch(response);
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            await Promise.resolve();
+            fake.emit({ type: 'chunk', content: 'first' });
+            controller.abort();
 
-            return provider.sendMessage(
-                [{ role: 'user', content: 'Hi' }],
-                { signal: controller.signal }
-            ).then(function () {
+            // Late chunk after abort — must not be surfaced.
+            fake.emit({ type: 'chunk', content: 'late' });
+            fake.emit({ type: 'complete' });
+
+            try {
+                await sendPromise;
                 throw new Error('Expected reject');
-            }, function (err) {
+            } catch (err) {
                 err.name.should.equal('AbortError');
-            });
+            }
+
+            received.should.deep.equal(['first']);
         });
     });
 
     describe('#destroy()', function () {
-        it('should abort any in-flight request', function () {
-            let capturedSignal = null;
-            const response = {
-                ok: true,
-                status: 200,
-                body: {
-                    getReader: function () {
-                        return {
-                            read: function () {
-                                return new Promise(function (resolve, reject) {
-                                    capturedSignal.addEventListener('abort', function () {
-                                        const err = new Error('Aborted');
-                                        err.name = 'AbortError';
-                                        reject(err);
-                                    });
-                                });
-                            },
-                            cancel: function () { return Promise.resolve(); }
-                        };
-                    }
-                }
-            };
+        it('should disconnect the port when a request has been sent', async function () {
+            const { provider, fake } = createProvider();
+            provider.sendMessage([{ role: 'user', content: 'Hi' }]).catch(function () { /* ignore */ });
 
-            const fetch = function (url, options) {
-                capturedSignal = options.signal;
-                return Promise.resolve(response);
-            };
+            await Promise.resolve();
+            provider.destroy();
 
-            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
-            const sendPromise = provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
-                throw new Error('Expected reject');
-            }, function (err) {
-                err.name.should.equal('AbortError');
-            });
+            fake.port.disconnected.should.be.true;
+        });
 
-            // Let the fetch resolve and read to start.
-            return Promise.resolve().then(function () {
-                return Promise.resolve();
-            }).then(function () {
-                provider.destroy();
-                return sendPromise;
-            });
+        it('should post {type:cancel} when an in-flight request is destroyed', async function () {
+            const { provider, fake } = createProvider();
+            provider.sendMessage([{ role: 'user', content: 'Hi' }]).catch(function () { /* ignore */ });
+
+            await Promise.resolve();
+            provider.destroy();
+
+            const cancelPosts = fake.posted.filter(function (m) { return m.type === 'cancel'; });
+            cancelPosts.should.have.length(1);
+        });
+
+        it('should be a no-op when never connected', function () {
+            const { provider, fake } = createProvider();
+            provider.destroy();
+            fake.port.disconnected.should.be.false;
+            fake.posted.should.have.length(0);
         });
     });
 });

--- a/tests/modules/ai/OpenAIProvider.spec.js
+++ b/tests/modules/ai/OpenAIProvider.spec.js
@@ -289,5 +289,29 @@ describe('OpenAIProvider', function () {
             fake.port.disconnected.should.be.false;
             fake.posted.should.have.length(0);
         });
+
+        it('should reject an in-flight sendMessage promise rather than leave it pending', async function () {
+            const { provider } = createProvider();
+            const sendPromise = provider.sendMessage([{ role: 'user', content: 'Hi' }]);
+
+            await Promise.resolve();
+            provider.destroy();
+
+            try {
+                await sendPromise;
+                throw new Error('Expected reject');
+            } catch (err) {
+                err.message.should.not.equal('Expected reject');
+            }
+        });
+    });
+
+    describe('#getUsageInfo()', function () {
+        it('should resolve to null (OpenAI-compatible endpoints expose no client-visible quota)', function () {
+            const { provider } = createProvider();
+            return provider.getUsageInfo().then(function (usage) {
+                (usage === null).should.be.true;
+            });
+        });
     });
 });

--- a/tests/modules/ai/OpenAIProvider.spec.js
+++ b/tests/modules/ai/OpenAIProvider.spec.js
@@ -1,0 +1,428 @@
+'use strict';
+
+const OpenAIProvider = require('../../../app/scripts/modules/ai/OpenAIProvider.js');
+
+function sseEvent(data) {
+    return 'data: ' + JSON.stringify(data) + '\n\n';
+}
+
+function contentEvent(text) {
+    return sseEvent({ choices: [{ delta: { content: text } }] });
+}
+
+function createResponse({ ok = true, status = 200, chunks = [], errorBody = null } = {}) {
+    let cursor = 0;
+    const encoder = new TextEncoder();
+
+    const body = {
+        getReader: function () {
+            return {
+                read: function () {
+                    if (cursor >= chunks.length) {
+                        return Promise.resolve({ done: true, value: undefined });
+                    }
+                    const chunk = chunks[cursor++];
+                    return Promise.resolve({
+                        done: false,
+                        value: typeof chunk === 'string' ? encoder.encode(chunk) : chunk
+                    });
+                },
+                cancel: function () {
+                    cursor = chunks.length;
+                    return Promise.resolve();
+                }
+            };
+        }
+    };
+
+    return {
+        ok: ok,
+        status: status,
+        body: body,
+        json: function () {
+            return Promise.resolve(errorBody || {});
+        },
+        text: function () {
+            return Promise.resolve(errorBody ? JSON.stringify(errorBody) : '');
+        }
+    };
+}
+
+function createFakeFetch(response) {
+    const calls = [];
+    const fetch = function (url, options) {
+        calls.push({ url: url, options: options });
+        if (typeof response === 'function') {
+            return Promise.resolve(response({ url: url, options: options }));
+        }
+        return Promise.resolve(response);
+    };
+    fetch.calls = calls;
+    return fetch;
+}
+
+function defaultConfig(overrides) {
+    return Object.assign({
+        baseUrl: 'http://localhost:6655/openai/v1',
+        apiKey: 'secret-key',
+        model: 'gpt-5.4'
+    }, overrides || {});
+}
+
+describe('OpenAIProvider', function () {
+    describe('#checkAvailability()', function () {
+        it('should return `ready` when baseUrl, apiKey, and model are all present', function () {
+            const provider = new OpenAIProvider(defaultConfig());
+            return provider.checkAvailability().then(function (result) {
+                result.status.should.equal('ready');
+            });
+        });
+
+        it('should return `unavailable` when baseUrl is missing', function () {
+            const provider = new OpenAIProvider(defaultConfig({ baseUrl: '' }));
+            return provider.checkAvailability().then(function (result) {
+                result.status.should.equal('unavailable');
+                result.message.should.contain('not configured');
+            });
+        });
+
+        it('should return `unavailable` when apiKey is missing', function () {
+            const provider = new OpenAIProvider(defaultConfig({ apiKey: '' }));
+            return provider.checkAvailability().then(function (result) {
+                result.status.should.equal('unavailable');
+            });
+        });
+
+        it('should return `unavailable` when model is missing', function () {
+            const provider = new OpenAIProvider(defaultConfig({ model: '' }));
+            return provider.checkAvailability().then(function (result) {
+                result.status.should.equal('unavailable');
+            });
+        });
+
+        it('should not make any network request', function () {
+            const fetch = createFakeFetch(createResponse());
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.checkAvailability().then(function () {
+                fetch.calls.length.should.equal(0);
+            });
+        });
+    });
+
+    describe('#sendMessage() — request wiring', function () {
+        it('should POST to `${baseUrl}/chat/completions` with the messages, model, and stream:true', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [contentEvent('hi'), 'data: [DONE]\n\n']
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            const messages = [
+                { role: 'system', content: 'You are helpful.' },
+                { role: 'user', content: 'Hello' }
+            ];
+            return provider.sendMessage(messages).then(function () {
+                fetch.calls.length.should.equal(1);
+                fetch.calls[0].url.should.equal('http://localhost:6655/openai/v1/chat/completions');
+                fetch.calls[0].options.method.should.equal('POST');
+                const body = JSON.parse(fetch.calls[0].options.body);
+                body.model.should.equal('gpt-5.4');
+                body.stream.should.equal(true);
+                body.messages.should.deep.equal(messages);
+            });
+        });
+
+        it('should include a Bearer Authorization header with the API key', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [contentEvent('hi'), 'data: [DONE]\n\n']
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                const headers = fetch.calls[0].options.headers;
+                headers.Authorization.should.equal('Bearer secret-key');
+                headers['Content-Type'].should.equal('application/json');
+            });
+        });
+    });
+
+    describe('#sendMessage() — SSE parsing', function () {
+        it('should accumulate content deltas across chunks and resolve with the full text', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [
+                    contentEvent('Hello, '),
+                    contentEvent('world'),
+                    contentEvent('!'),
+                    'data: [DONE]\n\n'
+                ]
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            const received = [];
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }],
+                { onChunk: function (t) { received.push(t); } }
+            ).then(function (fullText) {
+                received.should.deep.equal(['Hello, ', 'world', '!']);
+                fullText.should.equal('Hello, world!');
+            });
+        });
+
+        it('should buffer partial lines split across reads', function () {
+            const event = contentEvent('streamed');
+            const midpoint = Math.floor(event.length / 2);
+            const fetch = createFakeFetch(createResponse({
+                chunks: [
+                    event.slice(0, midpoint),
+                    event.slice(midpoint),
+                    'data: [DONE]\n\n'
+                ]
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }]
+            ).then(function (fullText) {
+                fullText.should.equal('streamed');
+            });
+        });
+
+        it('should handle multiple SSE events packed in one read', function () {
+            const packed = contentEvent('one') + contentEvent('two') + contentEvent('three') + 'data: [DONE]\n\n';
+            const fetch = createFakeFetch(createResponse({ chunks: [packed] }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }]
+            ).then(function (fullText) {
+                fullText.should.equal('onetwothree');
+            });
+        });
+
+        it('should ignore SSE events whose delta has no content field (e.g. role-only opener)', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [
+                    sseEvent({ choices: [{ delta: { role: 'assistant' } }] }),
+                    contentEvent('body'),
+                    'data: [DONE]\n\n'
+                ]
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }]
+            ).then(function (fullText) {
+                fullText.should.equal('body');
+            });
+        });
+
+        it('should stop cleanly at the [DONE] sentinel without treating it as JSON', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [contentEvent('done-test'), 'data: [DONE]\n\n', contentEvent('after')]
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }]
+            ).then(function (fullText) {
+                fullText.should.equal('done-test');
+            });
+        });
+    });
+
+    describe('#sendMessage() — error surfacing', function () {
+        it('should reject with the API error message on 401', function () {
+            const fetch = createFakeFetch(createResponse({
+                ok: false,
+                status: 401,
+                errorBody: { error: { message: 'Invalid API key' } }
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.message.should.contain('Invalid API key');
+            });
+        });
+
+        it('should reject with the API error message on 404', function () {
+            const fetch = createFakeFetch(createResponse({
+                ok: false,
+                status: 404,
+                errorBody: { error: { message: 'Model not found' } }
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.message.should.contain('Model not found');
+            });
+        });
+
+        it('should reject with the API error message on 429', function () {
+            const fetch = createFakeFetch(createResponse({
+                ok: false,
+                status: 429,
+                errorBody: { error: { message: 'Rate limited' } }
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.message.should.contain('Rate limited');
+            });
+        });
+
+        it('should never include the API key in error messages', function () {
+            const fetch = createFakeFetch(createResponse({
+                ok: false,
+                status: 401,
+                errorBody: { error: { message: 'Bad auth' } }
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig({ apiKey: 'super-secret-abc123' }), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.message.should.not.contain('super-secret-abc123');
+            });
+        });
+
+        it('should reject with a generic status message when the API body is not parseable', function () {
+            const fetch = function () {
+                return Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    body: null,
+                    json: function () { return Promise.reject(new Error('bad json')); },
+                    text: function () { return Promise.resolve(''); }
+                });
+            };
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            return provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.message.should.contain('500');
+            });
+        });
+    });
+
+    describe('#sendMessage() — cancellation', function () {
+        it('should reject with an AbortError when the signal is already aborted', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [contentEvent('x'), 'data: [DONE]\n\n']
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            const controller = new AbortController();
+            controller.abort();
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }],
+                { signal: controller.signal }
+            ).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.name.should.equal('AbortError');
+            });
+        });
+
+        it('should forward caller-signal aborts to the fetch call', function () {
+            const fetch = createFakeFetch(createResponse({
+                chunks: [contentEvent('x'), 'data: [DONE]\n\n']
+            }));
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            const controller = new AbortController();
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }],
+                { signal: controller.signal }
+            ).then(function () {
+                const fetchSignal = fetch.calls[0].options.signal;
+                (typeof fetchSignal === 'object').should.equal(true);
+                (fetchSignal.aborted === false).should.equal(true);
+                controller.abort();
+                (fetchSignal.aborted === true).should.equal(true);
+            });
+        });
+
+        it('should reject with AbortError when the signal aborts mid-stream', function () {
+            const controller = new AbortController();
+            let readCount = 0;
+            const encoder = new TextEncoder();
+
+            const response = {
+                ok: true,
+                status: 200,
+                body: {
+                    getReader: function () {
+                        return {
+                            read: function () {
+                                readCount++;
+                                if (readCount === 1) {
+                                    return Promise.resolve({
+                                        done: false,
+                                        value: encoder.encode(contentEvent('first'))
+                                    });
+                                }
+                                controller.abort();
+                                const err = new Error('Aborted');
+                                err.name = 'AbortError';
+                                return Promise.reject(err);
+                            },
+                            cancel: function () {
+                                return Promise.resolve();
+                            }
+                        };
+                    }
+                }
+            };
+
+            const fetch = createFakeFetch(response);
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+
+            return provider.sendMessage(
+                [{ role: 'user', content: 'Hi' }],
+                { signal: controller.signal }
+            ).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.name.should.equal('AbortError');
+            });
+        });
+    });
+
+    describe('#destroy()', function () {
+        it('should abort any in-flight request', function () {
+            let capturedSignal = null;
+            const response = {
+                ok: true,
+                status: 200,
+                body: {
+                    getReader: function () {
+                        return {
+                            read: function () {
+                                return new Promise(function (resolve, reject) {
+                                    capturedSignal.addEventListener('abort', function () {
+                                        const err = new Error('Aborted');
+                                        err.name = 'AbortError';
+                                        reject(err);
+                                    });
+                                });
+                            },
+                            cancel: function () { return Promise.resolve(); }
+                        };
+                    }
+                }
+            };
+
+            const fetch = function (url, options) {
+                capturedSignal = options.signal;
+                return Promise.resolve(response);
+            };
+
+            const provider = new OpenAIProvider(Object.assign(defaultConfig(), { fetch: fetch }));
+            const sendPromise = provider.sendMessage([{ role: 'user', content: 'Hi' }]).then(function () {
+                throw new Error('Expected reject');
+            }, function (err) {
+                err.name.should.equal('AbortError');
+            });
+
+            // Let the fetch resolve and read to start.
+            return Promise.resolve().then(function () {
+                return Promise.resolve();
+            }).then(function () {
+                provider.destroy();
+                return sendPromise;
+            });
+        });
+    });
+});

--- a/tests/modules/ai/OpenAIProvider.spec.js
+++ b/tests/modules/ai/OpenAIProvider.spec.js
@@ -68,6 +68,14 @@ describe('OpenAIProvider', function () {
             });
         });
 
+        it('should identify itself in the ready message so the banner does not fall back to a generic or Gemini-shaped label after setUrl / clearConversation re-emits it', function () {
+            const { provider } = createProvider({ model: 'gpt-4o-mini' });
+            return provider.checkAvailability().then(function (result) {
+                result.message.should.contain('OpenAI');
+                result.message.should.contain('gpt-4o-mini');
+            });
+        });
+
         it('should return `unavailable` when baseUrl is missing', function () {
             const { provider } = createProvider({ baseUrl: '' });
             return provider.checkAvailability().then(function (result) {

--- a/tests/modules/background/openaiHandler.spec.js
+++ b/tests/modules/background/openaiHandler.spec.js
@@ -1,0 +1,468 @@
+'use strict';
+
+const attachOpenAIHandler = require('../../../app/scripts/modules/background/openaiHandler.js');
+
+function createFakePort() {
+    const messageListeners = [];
+    const disconnectListeners = [];
+
+    const port = {
+        name: 'openai-api',
+        postMessage: function (message) {
+            port.posted.push(message);
+        },
+        onMessage: {
+            addListener: function (listener) {
+                messageListeners.push(listener);
+            }
+        },
+        onDisconnect: {
+            addListener: function (listener) {
+                disconnectListeners.push(listener);
+            }
+        },
+        posted: []
+    };
+
+    return {
+        port: port,
+        posted: port.posted,
+        deliver: function (message) {
+            messageListeners.forEach(function (l) { l(message); });
+        },
+        triggerDisconnect: function () {
+            disconnectListeners.forEach(function (l) { l(); });
+        }
+    };
+}
+
+function encodeChunks(strings) {
+    const encoder = new TextEncoder();
+    return strings.map(function (s) { return encoder.encode(s); });
+}
+
+function makeStreamingResponse(chunks, options) {
+    const opts = options || {};
+    let cursor = 0;
+    let cancelled = false;
+    const body = {
+        getReader: function () {
+            return {
+                read: function () {
+                    if (opts.signal && opts.signal.aborted) {
+                        const err = new Error('Aborted');
+                        err.name = 'AbortError';
+                        return Promise.reject(err);
+                    }
+                    if (cancelled || cursor >= chunks.length) {
+                        return Promise.resolve({ done: true, value: undefined });
+                    }
+                    return Promise.resolve({ done: false, value: chunks[cursor++] });
+                },
+                cancel: function () {
+                    cancelled = true;
+                    return Promise.resolve();
+                }
+            };
+        }
+    };
+    return {
+        ok: true,
+        status: 200,
+        body: body
+    };
+}
+
+function sseContent(text) {
+    return 'data: ' + JSON.stringify({ choices: [{ delta: { content: text } }] }) + '\n\n';
+}
+
+const validConfig = {
+    baseUrl: 'http://localhost:6655/openai/v1',
+    apiKey: 'secret-key',
+    model: 'gpt-5.4'
+};
+
+const validMessages = [{ role: 'user', content: 'Hi' }];
+
+describe('openaiHandler', function () {
+    describe('happy path — SSE streaming', function () {
+        it('should POST to `${baseUrl}/chat/completions` with the messages, model, and stream:true', function () {
+            const fake = createFakePort();
+            const fetchCalls = [];
+            const fetchImpl = function (url, options) {
+                fetchCalls.push({ url: url, options: options });
+                return Promise.resolve(makeStreamingResponse(encodeChunks([
+                    sseContent('hi'),
+                    'data: [DONE]\n\n'
+                ])));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                fetchCalls.should.have.length(1);
+                fetchCalls[0].url.should.equal('http://localhost:6655/openai/v1/chat/completions');
+                fetchCalls[0].options.method.should.equal('POST');
+                fetchCalls[0].options.headers.Authorization.should.equal('Bearer secret-key');
+                fetchCalls[0].options.headers['Content-Type'].should.equal('application/json');
+                const body = JSON.parse(fetchCalls[0].options.body);
+                body.model.should.equal('gpt-5.4');
+                body.stream.should.equal(true);
+                body.messages.should.deep.equal(validMessages);
+            });
+        });
+
+        it('should forward each SSE content delta as a `chunk` message then emit `complete` on [DONE]', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeStreamingResponse(encodeChunks([
+                    sseContent('Hello, '),
+                    sseContent('world'),
+                    sseContent('!'),
+                    'data: [DONE]\n\n'
+                ])));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 30); }).then(function () {
+                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
+                chunks.map(function (m) { return m.content; }).should.deep.equal(['Hello, ', 'world', '!']);
+                const completes = fake.posted.filter(function (m) { return m.type === 'complete'; });
+                completes.should.have.length(1);
+            });
+        });
+
+        it('should buffer SSE events split across reads', function () {
+            const fake = createFakePort();
+            const event = sseContent('streamed');
+            const midpoint = Math.floor(event.length / 2);
+            const encoder = new TextEncoder();
+
+            const fetchImpl = function () {
+                return Promise.resolve(makeStreamingResponse([
+                    encoder.encode(event.slice(0, midpoint)),
+                    encoder.encode(event.slice(midpoint)),
+                    encoder.encode('data: [DONE]\n\n')
+                ]));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 30); }).then(function () {
+                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
+                chunks.map(function (c) { return c.content; }).join('').should.equal('streamed');
+            });
+        });
+
+        it('should ignore SSE events whose delta has no content field (e.g. role-only opener)', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeStreamingResponse(encodeChunks([
+                    'data: ' + JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] }) + '\n\n',
+                    sseContent('body'),
+                    'data: [DONE]\n\n'
+                ])));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 30); }).then(function () {
+                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
+                chunks.map(function (c) { return c.content; }).should.deep.equal(['body']);
+            });
+        });
+
+        it('should stop at [DONE] and not process further chunks', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeStreamingResponse(encodeChunks([
+                    sseContent('done-test'),
+                    'data: [DONE]\n\n',
+                    sseContent('after')
+                ])));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 30); }).then(function () {
+                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
+                chunks.map(function (c) { return c.content; }).should.deep.equal(['done-test']);
+            });
+        });
+    });
+
+    describe('error surfacing', function () {
+        function makeErrorResponse(status, errorBody) {
+            return {
+                ok: false,
+                status: status,
+                json: function () { return Promise.resolve(errorBody); },
+                text: function () { return Promise.resolve(JSON.stringify(errorBody)); }
+            };
+        }
+
+        it('should post {type:error} with the API `error.message` on 401', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeErrorResponse(401, { error: { message: 'Invalid API key' } }));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(1);
+                errors[0].message.should.equal('Invalid API key');
+            });
+        });
+
+        it('should post {type:error} with the API `error.message` on 404', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeErrorResponse(404, { error: { message: 'Model not found' } }));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(1);
+                errors[0].message.should.equal('Model not found');
+            });
+        });
+
+        it('should post {type:error} with the API `error.message` on 429', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve(makeErrorResponse(429, { error: { message: 'Rate limited' } }));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(1);
+                errors[0].message.should.equal('Rate limited');
+            });
+        });
+
+        it('should fall back to `HTTP ${status}` when the API body is not parseable', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    json: function () { return Promise.reject(new Error('bad json')); },
+                    text: function () { return Promise.resolve(''); }
+                });
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(1);
+                errors[0].message.should.contain('500');
+            });
+        });
+
+        it('should surface fetch rejection as {type:error}', function () {
+            const fake = createFakePort();
+            const fetchImpl = function () {
+                return Promise.reject(new Error('network down'));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(1);
+                errors[0].message.should.contain('network down');
+            });
+        });
+
+        it('should never leak the apiKey into any posted message', function () {
+            const fake = createFakePort();
+            const secret = 'super-secret-abc123';
+            const fetchImpl = function () {
+                // API echoes the key in its error body (some misconfigured proxies do this).
+                return Promise.resolve(makeErrorResponse(401, {
+                    error: { message: 'Bad auth for key ' + secret }
+                }));
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({
+                type: 'send',
+                config: Object.assign({}, validConfig, { apiKey: secret }),
+                messages: validMessages
+            });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                // No posted message may contain the secret anywhere in its serialized form.
+                fake.posted.forEach(function (m) {
+                    JSON.stringify(m).should.not.contain(secret);
+                });
+            });
+        });
+    });
+
+    describe('cancellation', function () {
+        it('should abort the in-flight fetch when the port receives {type:cancel}', function () {
+            const fake = createFakePort();
+            let capturedSignal = null;
+            let readReject = null;
+
+            const fetchImpl = function (url, options) {
+                capturedSignal = options.signal;
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    body: {
+                        getReader: function () {
+                            return {
+                                read: function () {
+                                    return new Promise(function (_, reject) {
+                                        readReject = reject;
+                                    });
+                                },
+                                cancel: function () { return Promise.resolve(); }
+                            };
+                        }
+                    }
+                });
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
+                capturedSignal.aborted.should.be.false;
+                fake.deliver({ type: 'cancel' });
+                capturedSignal.aborted.should.be.true;
+                if (readReject) {
+                    const err = new Error('Aborted');
+                    err.name = 'AbortError';
+                    readReject(err);
+                }
+                return new Promise(function (resolve) { setTimeout(resolve, 10); });
+            }).then(function () {
+                // After cancel, no `complete` should ever be posted for this run.
+                const completes = fake.posted.filter(function (m) { return m.type === 'complete'; });
+                completes.should.have.length(0);
+            });
+        });
+
+        it('should abort the in-flight fetch when the port disconnects', function () {
+            const fake = createFakePort();
+            let capturedSignal = null;
+            let readReject = null;
+
+            const fetchImpl = function (url, options) {
+                capturedSignal = options.signal;
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    body: {
+                        getReader: function () {
+                            return {
+                                read: function () {
+                                    return new Promise(function (_, reject) {
+                                        readReject = reject;
+                                    });
+                                },
+                                cancel: function () { return Promise.resolve(); }
+                            };
+                        }
+                    }
+                });
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
+                capturedSignal.aborted.should.be.false;
+                fake.triggerDisconnect();
+                capturedSignal.aborted.should.be.true;
+                if (readReject) {
+                    const err = new Error('Aborted');
+                    err.name = 'AbortError';
+                    readReject(err);
+                }
+            });
+        });
+
+        it('should not post `complete` or further chunks after cancel arrives mid-stream', function () {
+            const fake = createFakePort();
+            const encoder = new TextEncoder();
+            let capturedSignal = null;
+            let firstReadResolve = null;
+            let secondReadResolve = null;
+
+            const fetchImpl = function (url, options) {
+                capturedSignal = options.signal;
+                let readCount = 0;
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    body: {
+                        getReader: function () {
+                            return {
+                                read: function () {
+                                    readCount++;
+                                    if (readCount === 1) {
+                                        return new Promise(function (resolve) {
+                                            firstReadResolve = resolve;
+                                        });
+                                    }
+                                    return new Promise(function (resolve, reject) {
+                                        secondReadResolve = { resolve: resolve, reject: reject };
+                                    });
+                                },
+                                cancel: function () { return Promise.resolve(); }
+                            };
+                        }
+                    }
+                });
+            };
+
+            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+
+            return new Promise(function (resolve) { setTimeout(resolve, 10); }).then(function () {
+                // Deliver the first SSE chunk. Handler will post `chunk` and issue another read.
+                firstReadResolve({ done: false, value: encoder.encode(sseContent('first')) });
+                return new Promise(function (resolve) { setTimeout(resolve, 10); });
+            }).then(function () {
+                // Cancel before the second read resolves.
+                fake.deliver({ type: 'cancel' });
+                capturedSignal.aborted.should.be.true;
+                // Reject the pending read with AbortError.
+                const err = new Error('Aborted');
+                err.name = 'AbortError';
+                secondReadResolve.reject(err);
+                return new Promise(function (resolve) { setTimeout(resolve, 10); });
+            }).then(function () {
+                const completes = fake.posted.filter(function (m) { return m.type === 'complete'; });
+                completes.should.have.length(0);
+                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
+                chunks.map(function (c) { return c.content; }).should.deep.equal(['first']);
+                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                errors.should.have.length(0);
+            });
+        });
+    });
+});

--- a/tests/modules/background/openaiHandler.spec.js
+++ b/tests/modules/background/openaiHandler.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const attachOpenAIHandler = require('../../../app/scripts/modules/background/openaiHandler.js');
+const parseSseEvent = attachOpenAIHandler.parseSseEvent;
+const DONE = attachOpenAIHandler.DONE;
 
 function createFakePort() {
     const messageListeners = [];
@@ -177,24 +179,32 @@ describe('openaiHandler', function () {
                 chunks.map(function (c) { return c.content; }).should.deep.equal(['body']);
             });
         });
+    });
 
-        it('should stop at [DONE] and not process further chunks', function () {
-            const fake = createFakePort();
-            const fetchImpl = function () {
-                return Promise.resolve(makeStreamingResponse(encodeChunks([
-                    sseContent('done-test'),
-                    'data: [DONE]\n\n',
-                    sseContent('after')
-                ])));
-            };
+    describe('parseSseEvent', function () {
+        it('should return the delta content string for a content event', function () {
+            parseSseEvent(sseContent('hello')).should.equal('hello');
+        });
 
-            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
-            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+        it('should return DONE for the [DONE] sentinel', function () {
+            parseSseEvent('data: [DONE]').should.equal(DONE);
+        });
 
-            return new Promise(function (resolve) { setTimeout(resolve, 30); }).then(function () {
-                const chunks = fake.posted.filter(function (m) { return m.type === 'chunk'; });
-                chunks.map(function (c) { return c.content; }).should.deep.equal(['done-test']);
-            });
+        it('should return empty string for a role-only opener (delta with no content)', function () {
+            const event = 'data: ' + JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] });
+            parseSseEvent(event).should.equal('');
+        });
+
+        it('should return empty string for a comment/keep-alive line (no data: prefix)', function () {
+            parseSseEvent(': keep-alive').should.equal('');
+        });
+
+        it('should return empty string for a non-JSON data payload', function () {
+            parseSseEvent('data: not json').should.equal('');
+        });
+
+        it('should return empty string when choices is empty', function () {
+            parseSseEvent('data: ' + JSON.stringify({ choices: [] })).should.equal('');
         });
     });
 
@@ -208,51 +218,25 @@ describe('openaiHandler', function () {
             };
         }
 
-        it('should post {type:error} with the API `error.message` on 401', function () {
-            const fake = createFakePort();
-            const fetchImpl = function () {
-                return Promise.resolve(makeErrorResponse(401, { error: { message: 'Invalid API key' } }));
-            };
+        [
+            { status: 401, message: 'Invalid API key' },
+            { status: 404, message: 'Model not found' },
+            { status: 429, message: 'Rate limited' }
+        ].forEach(function (testCase) {
+            it('should post {type:error} with the API `error.message` on ' + testCase.status, function () {
+                const fake = createFakePort();
+                const fetchImpl = function () {
+                    return Promise.resolve(makeErrorResponse(testCase.status, { error: { message: testCase.message } }));
+                };
 
-            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
-            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
+                attachOpenAIHandler(fake.port, { fetch: fetchImpl });
+                fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
 
-            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
-                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
-                errors.should.have.length(1);
-                errors[0].message.should.equal('Invalid API key');
-            });
-        });
-
-        it('should post {type:error} with the API `error.message` on 404', function () {
-            const fake = createFakePort();
-            const fetchImpl = function () {
-                return Promise.resolve(makeErrorResponse(404, { error: { message: 'Model not found' } }));
-            };
-
-            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
-            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
-
-            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
-                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
-                errors.should.have.length(1);
-                errors[0].message.should.equal('Model not found');
-            });
-        });
-
-        it('should post {type:error} with the API `error.message` on 429', function () {
-            const fake = createFakePort();
-            const fetchImpl = function () {
-                return Promise.resolve(makeErrorResponse(429, { error: { message: 'Rate limited' } }));
-            };
-
-            attachOpenAIHandler(fake.port, { fetch: fetchImpl });
-            fake.deliver({ type: 'send', config: validConfig, messages: validMessages });
-
-            return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
-                const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
-                errors.should.have.length(1);
-                errors[0].message.should.equal('Rate limited');
+                return new Promise(function (resolve) { setTimeout(resolve, 20); }).then(function () {
+                    const errors = fake.posted.filter(function (m) { return m.type === 'error'; });
+                    errors.should.have.length(1);
+                    errors[0].message.should.equal(testCase.message);
+                });
             });
         });
 


### PR DESCRIPTION
> Stacked on #381 (PR1). Base is `split/pr1-provider-refactor`; it will auto-retarget to `master` when PR1 merges.

## What this does

Adds a second provider — `OpenAIProvider` — behind the Provider interface and registry that PR1 introduced. This is a foundation slice: the provider is registered and fully unit-tested, but **Gemini Nano stays the default and there is no UI to switch to OpenAI yet.** The settings modal and storage-driven provider selection follow in a later PR.

Four commits:

1. **Add `OpenAIProvider` behind the registry.** fetch + SSE streaming, Bearer auth, `[DONE]` sentinel, cross-read line buffering, cancellation via `AbortSignal`, and API-error surfacing that never leaks the apiKey. `checkAvailability` returns `ready` only when `baseUrl`, `apiKey`, and `model` are all set (no network ping). Registered under `'openai'` with a `configSchema`.
2. **Move network I/O into the service worker.** The panel cannot reach arbitrary origins under the extension CSP, so the provider proxies fetch/stream through a `background/openaiHandler.js` port protocol.
3. **CSP fix** so the service worker fetch is allowed.
4. **Stop hardcoding the Gemini ready-message in the controller.** `AssistantController` had three `'Gemini Nano is ready'` strings that clobbered the banner on `setUrl`, `clearConversation`, and post-streaming recovery. Cache the active provider's own ready message and re-emit that instead. Invisible until a non-Gemini provider is actually selected.

## No user-visible change

`AIChat.js` is byte-identical to PR1 — `providerName` stays `'gemini-nano'`, `providerConfig` stays `{}`. An end user sees exactly the PR1 behavior. OpenAI is reachable only by constructing the controller with `providerName: 'openai'` and a config, which nothing in the shipped UI does yet.

## What is deliberately NOT here

- No settings modal, gear icon, or provider picker.
- No storage-driven selection or `setProvider` hot-swap.
- No `not-configured` banner action or token-counter/feature-detection UI work.

All of that is the next slice.

## Testing

`npx grunt karma:CI` — 614 tests pass. `eslint` and `jshint` clean.

Manual (pending a live gateway): construct `AIChat` with `providerName: 'openai'` + gateway config, confirm `checkAvailability` reports ready and a send round-trips through the service worker (fetch appears under the extension's service worker in the Network tab, not the panel). Confirm the default Gemini path is untouched.

## Review path

Read `OpenAIProvider.js` and `background/openaiHandler.js` (the port protocol between them). `providers/index.js` is the one-line registry entry. The `AssistantController.js` change is the ready-message cache. Everything else is tests.
