### PR TITLE
Feat/webc cdn enum dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 [![Build Status](https://travis-ci.org/SAP/ui5-inspector.svg?branch=master)](https://travis-ci.org/SAP/ui5-inspector)
 [![Coverage Status](https://coveralls.io/repos/SAP/ui5-inspector/badge.svg?branch=master&service=github)](https://coveralls.io/github/SAP/ui5-inspector?branch=master)
-[![REUSE status](https://api.reuse.software/badge/github.com/SAP/ui5-inspector)](https://api.reuse.software/info/github.com/SAP/ui5-inspector)
+[![REUSE status](https://api.reuse.software/badge/github.com/UI5/inspector)](https://api.reuse.software/info/github.com/UI5/inspector)
 
 # About UI5 Inspector
 
 UI5 Inspector is a standard Chrome or Edge extension for debugging and getting to know UI5 applications.
 
 It's free and open source: UI5 Inspector is licensed under the Apache License, Version 2.0.
-See [LICENSE.txt](https://github.com/SAP/ui5-inspector/blob/master/LICENSE.txt) for more information.
+See [LICENSE.txt](https://github.com/UI5/inspector/blob/master/LICENSE.txt) for more information.
 
 ## Direct download and use
 
 The latest released version can be downloaded and installed as follows:
 
-1. Download zip file from [Releases](https://github.com/SAP/ui5-inspector/releases)
+1. Download zip file from [Releases](https://github.com/UI5/inspector/releases)
 2. Unpack to a directory
 3. In Chrome open as url: `chrome://extensions/`. Alternatively, you can access `edge://extensions/` when in Edge. The extensions page is also reachable via the browser's menu.
 4. Check “Developer mode” setting and then choose "Load unpacked extension..."

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -28,7 +28,7 @@
         }
     ],
     "content_security_policy": {
-        "extension_pages": "default-src 'self'; img-src 'self' data:; style-src 'unsafe-inline';"
+        "extension_pages": "default-src 'self'; connect-src 'self' https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data:; style-src 'unsafe-inline';"
     },
     "description": "With the UI5 Inspector, you can easily debug and support your OpenUI5 or SAPUI5-based apps.",
     "devtools_page": "/html/devtools/index.html",

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -31,6 +31,7 @@
     var ControllerDetailView = require('../../../modules/ui/ControllerDetailView.js');
     var OElementsRegistryMasterView = require('../../../modules/ui/OElementsRegistryMasterView.js');
     var AIChat = require('../../../modules/ui/AIChat.js');
+    var WebCEnumRegistry = require('../../../modules/webc/WebCEnumRegistry.js');
 
 
     // Apply theme
@@ -60,6 +61,40 @@
     var framesSelect;
     var displayFrameData;
     var updateSupportabilityOverlay;
+    // Resolves UI5 Web Components enum properties to dropdown values by
+    // fetching the CDN manifest for the detected framework version. Runs here
+    // (extension context) rather than in the page, whose CSP often blocks the
+    // CDN hosts.
+    var webcEnumRegistry = new WebCEnumRegistry();
+
+    // Monotonic counter bumped on every control selection for the displayed
+    // frame. Web Components rendering is deferred behind an async manifest
+    // fetch, so this lets a deferred render detect that a newer selection has
+    // superseded it and bail instead of clobbering the current one.
+    var controlSelectSeq = 0;
+
+    // Rewrite a Web Components property section's `types` in place: where a
+    // property is a known enum (per the primed CDN manifest), replace its
+    // plain string type with the `{label: value}` map the DataView needs to
+    // render a <select>. Unknown properties keep their string type (editable
+    // text field). Safe to call when nothing is primed — it just no-ops.
+    function _enrichWebcEnumTypes(own, version) {
+        if (!own || !own.types || !own.meta || !own.meta.tag) {
+            return;
+        }
+        var tag = own.meta.tag;
+        Object.keys(own.types).forEach(function (property) {
+            // Only convert declared string types; leave booleans, objects and
+            // already-resolved enum maps untouched.
+            if (typeof own.types[property] !== 'string') {
+                return;
+            }
+            var values = webcEnumRegistry.getEnumValues(version, tag, property);
+            if (values) {
+                own.types[property] = values;
+            }
+        });
+    }
     // Synthetic root inserted under the merged tree (mixed pages) to group all
     // WebC controls under one expandable header. Its id ('__webc_root__') is
     // reserved: selecting or hovering it in the tree must be a no-op since it
@@ -720,7 +755,23 @@
             frameData[frameId].controlAggregations = message.controlAggregations;
             frameData[frameId].controlEvents = message.controlEvents;
 
-            if (framesSelect.getSelectedId() === frameId) {
+            if (framesSelect.getSelectedId() !== frameId) {
+                return;
+            }
+
+            // Capture the selection token now; the deferred Web Components
+            // render below can resolve out of order (different runtime
+            // versions / fetch latencies), so it must verify it is still the
+            // current selection before applying its data.
+            var token = ++controlSelectSeq;
+
+            var render = function () {
+                // A newer selection (or a frame switch) has superseded this
+                // one while its manifest fetch was in flight — drop the stale
+                // render.
+                if (token !== controlSelectSeq || framesSelect.getSelectedId() !== frameId) {
+                    return;
+                }
                 controlProperties.setData(message.controlProperties);
                 controlBindingInfoLeftDataView.setData(message.controlBindings);
                 controlAggregations.setData(message.controlAggregations);
@@ -753,6 +804,26 @@
                     },
                     appInfo: frameData[frameId].applicationInformation
                 });
+            };
+
+            // For UI5 Web Components, resolve enum properties to dropdown values
+            // from the CDN manifest before rendering. The manifest fetch is
+            // async (cached after the first hit per version); on any failure we
+            // just render with plain-string values. Classic UI5 renders
+            // synchronously as before.
+            var own = message.controlProperties && message.controlProperties.own;
+            if (own && own.meta && own.meta.isWebComponent) {
+                var webcTree = frameData[frameId].controlTreeWebC;
+                // Prefer the per-component runtime version (multi-runtime pages
+                // can mix versions); fall back to the tree's primary runtime
+                // version when the element didn't report one.
+                var version = (own.meta && own.meta.version) ||
+                    (webcTree && webcTree.versionInfo && webcTree.versionInfo.version);
+                webcEnumRegistry.prime(version).then(function () {
+                    _enrichWebcEnumTypes(own, version);
+                }, function () { /* keep plain strings */ }).then(render);
+            } else {
+                render();
             }
         },
 

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -2,6 +2,13 @@
 (function () {
     'use strict';
 
+    // This controller function was already at the configured maxstatements
+    // ceiling (60); adding the App Info merge helpers (WebC + classic UI5)
+    // tips it over. Raise the scoped limit rather than fragment the tightly
+    // coupled panel wiring — same approach as the maxcomplexity directives
+    // elsewhere in the codebase.
+    /* jshint maxstatements: 70 */
+
     // ================================================================================
     // Main controller for 'UI5' tab in devtools
     // ================================================================================
@@ -425,6 +432,50 @@
         return ui5Tree || {};
     }
 
+    // Merge the classic UI5 and Web Components application-info section maps
+    // for the App Info tab. On mixed pages both frameworks contribute sections;
+    // classic UI5 keeps its original top-level sections and the Web Components
+    // info arrives as a single self-labelled "UI5 Web Components" group (see
+    // webcMain.js _buildApplicationInfo), so the two read as distinct without
+    // any title rewriting and their keys never collide. Classic sections are
+    // inserted first so they render above the Web Components group. On
+    // single-framework pages the relevant map is returned unchanged.
+    function _getMergedApplicationInfo(frameId) {
+        var fd = frameData[frameId];
+        if (!fd) {
+            return {};
+        }
+        var ui5Info = fd.applicationInformationUI5;
+        var webcInfo = fd.applicationInformationWebC;
+
+        if (ui5Info && webcInfo) {
+            var merged = {};
+            var key;
+            for (key in ui5Info) {
+                merged[key] = ui5Info[key];
+            }
+            for (key in webcInfo) {
+                merged[key] = webcInfo[key];
+            }
+            return merged;
+        }
+
+        return webcInfo || ui5Info || {};
+    }
+
+    // Recompute the merged App Info map for a frame, cache it on frameData
+    // (used by displayFrameData and the AI chat context), and push it to the
+    // App Info tab when that frame is currently selected.
+    function _refreshAppInfo(frameId) {
+        var merged = _getMergedApplicationInfo(frameId);
+        if (frameData[frameId]) {
+            frameData[frameId].applicationInformation = merged;
+        }
+        if (framesSelect.getSelectedId() === frameId) {
+            appInfo.setData(merged);
+        }
+    }
+
     displayFrameData = function (options) {
         var frameId = options.selectedId;
         var oldFrameId = options.oldSelectedId;
@@ -436,7 +487,7 @@
         if (UI5Data) {
             controlTree.setData(_getMergedControlTree(frameId));
             UI5Data.selectedElementId && controlTree.setSelectedElement(UI5Data.selectedElementId);
-            appInfo.setData(UI5Data.applicationInformation);
+            appInfo.setData(_getMergedApplicationInfo(frameId));
             UI5Data.elementRegistry && oElementsRegistryMasterView.setData(UI5Data.elementRegistry);
 
             controlProperties.setData(UI5Data.controlProperties || {});
@@ -592,7 +643,7 @@
             var frameId = messageSender.frameId;
             frameData[frameId].controlTree = message.controlTree;
             frameData[frameId].controlTreeUI5 = message.controlTree;
-            frameData[frameId].applicationInformation = message.applicationInformation;
+            frameData[frameId].applicationInformationUI5 = message.applicationInformation;
             frameData[frameId].elementRegistry = message.elementRegistry;
 
             if (framesSelect.getSelectedId() === frameId) {
@@ -600,9 +651,12 @@
 
                 // Set URL for AI Chat history
                 aiChat.setUrl(frameData[frameId].url);
-                appInfo.setData(message.applicationInformation);
                 oElementsRegistryMasterView.setData(message.elementRegistry);
             }
+
+            // Merge with any Web Components info already collected for this
+            // frame and refresh the App Info tab (see _getMergedApplicationInfo).
+            _refreshAppInfo(frameId);
         },
 
         /**
@@ -802,23 +856,17 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
-            // Precedence rule for the App Info tab on mixed pages: classic UI5
-            // wins because it provides richer info (loaded libraries, modules,
-            // bootstrap config, URL parameters), whereas WebC only emits a
-            // minimal "General" section. We populate from WebC only when
-            // classic hasn't already filled this in.
-            if (!frameData[frameId].applicationInformation) {
-                frameData[frameId].applicationInformation = message.applicationInformation;
-            }
+            frameData[frameId].applicationInformationWebC = message.applicationInformation;
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
-                // Avoid overwriting the App Info tab if classic UI5 will
-                // populate it shortly (or already did) — same precedence rule.
-                if (!frameData[frameId].isUI5Detected) {
-                    appInfo.setData(frameData[frameId].applicationInformation);
-                }
             }
+
+            // On mixed pages the classic UI5 sections and the Web Components
+            // sections are shown together in the App Info tab; on pure-WebC
+            // pages only the WebC sections are present (see
+            // _getMergedApplicationInfo).
+            _refreshAppInfo(frameId);
         },
 
         'on-application-dom-update-webc': function (message, messageSender) {
@@ -827,10 +875,15 @@
                 frameData[frameId] = {};
             }
             frameData[frameId].controlTreeWebC = message.controlTree;
+            // Tag usage counts and the runtime list can change as the DOM
+            // mutates, so refresh the stored WebC app info too.
+            frameData[frameId].applicationInformationWebC = message.applicationInformation;
 
             if (framesSelect.getSelectedId() === frameId) {
                 controlTree.setData(_getMergedControlTree(frameId));
             }
+
+            _refreshAppInfo(frameId);
         },
 
         'on-ping-frames': function(message) {

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -85,7 +85,21 @@
                 editableValues: true
             },
             data: formattedProps,
-            types: types
+            types: types,
+            // Lets the panel recognise a Web Components selection and resolve
+            // enum dropdowns from the CDN manifest (see the panel's
+            // WebCEnumRegistry). `tag` is the *pure* (unscoped) custom element
+            // tag, e.g. "ui5-button" — the DOM tag may carry an app/runtime
+            // scoping suffix (ui5-button-<suffix>) that the manifest doesn't
+            // know about.
+            meta: {
+                isWebComponent: true,
+                tag: (properties.own.meta && properties.own.meta.pureTag) || title,
+                // Version of the runtime this element belongs to, resolved per
+                // element so multi-runtime pages match each component to its
+                // own CDN manifest rather than the primary runtime's version.
+                version: properties.own.meta && properties.own.meta.version
+            }
         };
         return result;
     }

--- a/app/scripts/injected/webcMain.js
+++ b/app/scripts/injected/webcMain.js
@@ -172,6 +172,20 @@
         };
     }
 
+    // Escape HTML-significant characters. The DataView escapes string *values*
+    // but not section *titles* or *keys* (DataViewHelper._wrapInTag interpolates
+    // them raw). Any page-controlled string that ends up in a title/key — e.g. a
+    // runtime's alias or scoping suffix — must be escaped here first, otherwise a
+    // hostile page could inject markup into the DevTools panel.
+    function _escapeHTML(value) {
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     // Stringify a configuration value for display in the App Info tab.
     function _formatConfigValue(value) {
         if (value === null || value === undefined) {
@@ -187,20 +201,20 @@
         return value;
     }
 
-    // Build application info in the same shape as classic UI5's
-    // applicationUtils.getApplicationInfo(). Surfaces what the framework
-    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
-    // configuration (theme, language, timezone, ...), registered tags and
-    // features, and a list of runtimes when more than one is active on the
-    // page.
     // --- App Info section builders. Each returns a {options, data} section
     // or null if there's nothing to report. ---
 
-    function _generalSection(common) {
+    function _generalSection(common, runtimes) {
         var general = {};
         general[common.frameworkName] = common.version || '(unknown)';
-        if (common.description) {
-            general.Description = common.description;
+        general.Runtimes = runtimes.length;
+        // Interop is page-level; read it from the primary (first) runtime.
+        var primary = runtimes[0] || {};
+        if (typeof primary.openUI5Detected === 'boolean') {
+            general['OpenUI5 detected'] = primary.openUI5Detected;
+            if (typeof primary.openUI5LoadedFirst === 'boolean') {
+                general['OpenUI5 loaded first'] = primary.openUI5LoadedFirst;
+            }
         }
         general['User Agent'] = navigator.userAgent;
         general.Application = location.href;
@@ -231,11 +245,26 @@
         });
     }
 
-    function _registeredTagsSection(tags) {
-        if (!Array.isArray(tags) || !tags.length) {
+    // Tags with at least one live instance on the page. Object keys sort
+    // alphabetically in the DataView; the value is the instance count.
+    function _usedTagsSection(usedTags) {
+        if (!Array.isArray(usedTags) || !usedTags.length) {
             return null;
         }
-        return _section('Registered tags (' + tags.length + ')', _asSortedArray(tags), false);
+        var data = {};
+        for (var i = 0; i < usedTags.length; i++) {
+            data[usedTags[i].tag] = usedTags[i].count;
+        }
+        return _section('Tags in use (' + usedTags.length + ')', data);
+    }
+
+    // Registered tags that are not currently instantiated anywhere on the page.
+    function _unusedTagsSection(unusedTags) {
+        if (!Array.isArray(unusedTags) || !unusedTags.length) {
+            return null;
+        }
+        return _section('Tags registered, not in use (' + unusedTags.length + ')',
+            _asSortedArray(unusedTags), false);
     }
 
     function _registeredFeaturesSection(features) {
@@ -245,59 +274,96 @@
         return _section('Registered features (' + features.length + ')', _asSortedArray(features), false);
     }
 
-    function _interopSection(primary) {
-        if (typeof primary.openUI5Detected !== 'boolean') {
-            return null;
+    // Left-pad the runtime index so per-runtime section titles keep numeric
+    // order under the DataView's alphabetical key sort. Only widens once indices
+    // reach two digits (11+ runtimes); typical pages keep the bare "Runtime 0".
+    function _padIndex(index, total) {
+        var width = String(Math.max(total - 1, 0)).length;
+        var s = String(index);
+        while (s.length < width) {
+            s = '0' + s;
         }
-        var interop = {};
-        interop['OpenUI5 detected'] = primary.openUI5Detected;
-        if (typeof primary.openUI5LoadedFirst === 'boolean') {
-            interop['OpenUI5 loaded first'] = primary.openUI5LoadedFirst;
-        }
-        return _section('Interop', interop);
+        return s;
     }
 
-    function _runtimesSection(runtimes) {
-        if (runtimes.length <= 1) {
-            return null;
+    // A concise per-runtime label, e.g. "Runtime 0 — v2.19.0 (myapp)" or,
+    // when there's no alias, "Runtime 0 — v2.19.0 [scoping-suffix]". The
+    // version/alias/scoping-suffix are page-controlled and land in a section
+    // title, so escape them (the DataView does not escape titles).
+    function _runtimeLabel(rt, total) {
+        var label = 'Runtime ' + _padIndex(rt.index, total || 1) +
+            ' — v' + _escapeHTML(rt.version || 'unknown');
+        if (rt.alias) {
+            label += ' (' + _escapeHTML(rt.alias) + ')';
+        } else if (rt.scopingSuffix) {
+            label += ' [' + _escapeHTML(rt.scopingSuffix) + ']';
         }
-        var data = [];
-        for (var r = 0; r < runtimes.length; r++) {
-            var rt = runtimes[r];
-            data.push((rt.alias ? rt.alias + ' — ' : '') +
-                (rt.description || ('version ' + (rt.version || 'unknown'))));
-        }
-        return _section('Runtimes (' + runtimes.length + ')', data);
+        return label;
     }
 
-    // Build application info in the same shape as classic UI5's
-    // applicationUtils.getApplicationInfo(). Surfaces what the framework
-    // exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts):
-    // configuration (theme, language, timezone, ...), registered tags and
-    // features, and a list of runtimes when more than one is active on the
-    // page.
+    // One expandable section for a single runtime: its identity fields plus
+    // nested Configuration / tags-in-use / unused-tags / features sub-sections,
+    // each scoped to that runtime. Collapsed by default — a single runtime can
+    // register hundreds of tags.
+    function _runtimeDetailSection(rt, total) {
+        var data = { Version: rt.version || '(unknown)' };
+        if (rt.alias) {
+            data.Alias = rt.alias;
+        }
+        if (rt.scopingSuffix) {
+            data['Scoping suffix'] = rt.scopingSuffix;
+        }
+        if (rt.importMetaUrl) {
+            data['Runtime URL'] = rt.importMetaUrl;
+        }
+
+        var nested = [
+            _configurationSection(rt.configuration),
+            _usedTagsSection(rt.usedTags),
+            _unusedTagsSection(rt.unusedTags),
+            _registeredFeaturesSection(rt.registeredFeatures)
+        ];
+        for (var i = 0; i < nested.length; i++) {
+            if (nested[i]) {
+                data[nested[i].options.title] = nested[i];
+            }
+        }
+
+        return _section(_runtimeLabel(rt, total), data, false);
+    }
+
+    // Build the Application-Info payload for the App Info tab. Everything the
+    // framework exposes through `meta.Runtimes` (see packages/base/src/Runtimes.ts)
+    // is grouped under a single self-labelled "UI5 Web Components" section so it
+    // reads as distinct from the classic SAPUI5 sections on mixed pages. The
+    // group holds a General summary and one collapsible section per runtime (with
+    // that runtime's configuration, used/unused tags and features).
     function _buildApplicationInfo(frameworkInformation) {
         var common = frameworkInformation.commonInformation;
         var runtimes = (frameworkInformation.runtimes && frameworkInformation.runtimes.length) ?
             frameworkInformation.runtimes : [];
-        var primary = runtimes[0] || {};
-        var sections = {
-            common: _generalSection(common),
-            configuration: _configurationSection(primary.configuration),
-            registeredTags: _registeredTagsSection(primary.registeredTags),
-            registeredFeatures: _registeredFeaturesSection(primary.registeredFeatures),
-            interop: _interopSection(primary),
-            runtimes: _runtimesSection(runtimes)
-        };
 
-        var result = {};
-        var keys = Object.keys(sections);
-        for (var i = 0; i < keys.length; i++) {
-            if (sections[keys[i]]) {
-                result[keys[i]] = sections[keys[i]];
-            }
+        var groupData = { General: _generalSection(common, runtimes) };
+
+        for (var r = 0; r < runtimes.length; r++) {
+            var section = _runtimeDetailSection(runtimes[r], runtimes.length);
+            groupData[section.options.title] = section;
         }
-        return result;
+
+        var title = 'UI5 Web Components';
+        if (runtimes.length > 1) {
+            title += ' — ' + runtimes.length + ' runtimes (primary v' +
+                _escapeHTML(common.version || 'unknown') + ')';
+        } else if (common.version) {
+            title += ' (v' + _escapeHTML(common.version) + ')';
+        }
+
+        return {
+            webcRoot: {
+                options: { title: title, expandable: true, expanded: true },
+                data: groupData
+            }
+        };
     }
 
     // Send the current control tree to the panel

--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -237,17 +237,34 @@ var controlProperties = (function () {
 
     /**
      * Formatter for the type enums.
+     *
+     * Resolves an enum's keys/values so the DataView can render a dropdown.
+     * The values are read from the registered UI5 DataType
+     * (DataType.getType(type).getEnumValues()) rather than from the global
+     * namespace: classic libraries (e.g. sap.m) expose their enums on
+     * window.sap.m.<Enum>, but the generated UI5 Web Components wrappers are
+     * AMD-only modules that register their enums as DataTypes without ever
+     * placing them on the global namespace. The legacy global-namespace walk
+     * (_transformStringTypeToObject) is kept as a fallback for runtimes whose
+     * DataType lacks getEnumValues().
      * @param {string | Object} type
      * @private
      */
     function _formatTypes (type) {
-        var objectType;
-        if (type.startsWith('sap.') && sap.ui.require('sap/ui/base/DataType').getType(type).getDefaultValue()) {
-            objectType = _transformStringTypeToObject(type);
-        } else {
-            objectType = type;
+        if (typeof type !== 'string' || !type.startsWith('sap.')) {
+            return type;
         }
-        return objectType;
+
+        var DataType = sap.ui.require('sap/ui/base/DataType');
+        var oType = DataType && DataType.getType(type);
+        if (oType && typeof oType.isEnumType === 'function' && oType.isEnumType()) {
+            if (typeof oType.getEnumValues === 'function') {
+                return oType.getEnumValues();
+            }
+            return _transformStringTypeToObject(type);
+        }
+
+        return type;
     }
 
     /**

--- a/app/scripts/modules/webc/WebCEnumRegistry.js
+++ b/app/scripts/modules/webc/WebCEnumRegistry.js
@@ -1,0 +1,415 @@
+'use strict';
+
+/**
+ * Resolves UI5 Web Components enum properties to their possible values so the
+ * DataView can render a dropdown for them.
+ *
+ * Why this exists
+ * ---------------
+ * The runtime metadata of a UI5 web component only exposes a property's type
+ * as a JavaScript constructor (`String`, `Boolean`, ...). Enum types are
+ * compiled to plain strings, so at runtime we cannot tell that `design` on
+ * `ui5-button` is a `ButtonDesign` enum, let alone enumerate its values. This
+ * is why pure web components and their React wrappers show a plain editable
+ * string instead of a dropdown (unlike the OpenUI5 wrappers, which register
+ * their enums as `sap/ui/base/DataType` and are handled in
+ * modules/injected/controlUtils.js).
+ *
+ * The missing information lives in the Custom Elements Manifest published on
+ * npm as `dist/custom-elements-internal.json`. For every component it lists
+ * the attributes with their enum values inline as a union of string literals,
+ * e.g. for `ui5-button`'s `design`:
+ *
+ *   "type": { "text": "\"Default\" | \"Emphasized\" | \"Positive\" | ..." }
+ *
+ * We fetch that manifest for the exact framework version detected on the page
+ * (falling back to the nearest published minor) and build a
+ * `tag -> property -> {label: value}` lookup that the panel uses to enrich the
+ * property types before handing them to the DataView.
+ *
+ * Where this runs
+ * ---------------
+ * In an extension context (the DevTools panel), never in the inspected page:
+ * the page's own CSP frequently blocks third-party hosts like jsDelivr. The
+ * extension page CSP is relaxed in manifest.json to allow the CDN hosts.
+ *
+ * @param {Object} [options]
+ * @param {Function} [options.fetch] - `fetch`-compatible function. Defaults to the global `fetch`.
+ * @param {Object} [options.storage] - `chrome.storage.local`-compatible surface (`get`, `set`).
+ *                                      Defaults to `chrome.storage.local`. Optional: without it the
+ *                                      registry still works, just without cross-session caching.
+ * @param {string[]} [options.packages] - npm package names to fetch manifests for.
+ * @constructor
+ */
+function WebCEnumRegistry(options) {
+    options = options || {};
+
+    this._fetch = options.fetch ||
+        (typeof fetch !== 'undefined' ? fetch.bind(typeof self !== 'undefined' ? self : this) : null);
+
+    var storage = options.storage;
+    if (!storage && typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+        storage = chrome.storage.local;
+    }
+    this._storage = storage || null;
+
+    this._packages = options.packages || WebCEnumRegistry.DEFAULT_PACKAGES;
+
+    // version -> {tag: {property: {label: value}}}
+    this._memory = Object.create(null);
+    // version -> Promise (in-flight prime, so concurrent selects share one fetch)
+    this._pending = Object.create(null);
+}
+
+/**
+ * Web Components family packages that publish a custom-elements-internal.json.
+ * They share a single release version, so the detected runtime version is used
+ * for all of them. Packages that don't resolve are skipped.
+ * @type {string[]}
+ */
+WebCEnumRegistry.DEFAULT_PACKAGES = [
+    '@ui5/webcomponents',
+    '@ui5/webcomponents-fiori',
+    '@ui5/webcomponents-compat',
+    '@ui5/webcomponents-ai'
+];
+
+/**
+ * CDN hosts, in preference order: jsDelivr first, unpkg as fallback.
+ * @type {string[]}
+ */
+WebCEnumRegistry.CDN_HOSTS = [
+    'https://cdn.jsdelivr.net/npm/',
+    'https://unpkg.com/'
+];
+
+/**
+ * @type {string}
+ */
+WebCEnumRegistry.MANIFEST_PATH = '/dist/custom-elements-internal.json';
+
+/**
+ * Maximum number of per-version enum maps kept in `chrome.storage.local`.
+ * Bounds cache growth on machines that inspect many framework versions over
+ * time (now more likely, since multi-runtime pages prime several versions);
+ * the least-recently-saved version is evicted past this cap.
+ * @type {number}
+ */
+WebCEnumRegistry.MAX_STORED_VERSIONS = 8;
+
+/**
+ * Storage key holding the ordered list of cached versions (oldest first) used
+ * to drive least-recently-saved eviction.
+ * @type {string}
+ */
+WebCEnumRegistry.INDEX_KEY = 'webc_enums_index';
+
+/**
+ * @param {string} version
+ * @returns {string}
+ * @private
+ */
+WebCEnumRegistry.storageKey = function (version) {
+    return 'webc_enums_' + version;
+};
+
+/**
+ * Parse a single attribute `type.text` into an enum value map, or null if it
+ * is not an enum (i.e. not a union of two-or-more quoted string literals).
+ *
+ * @param {string} typeText - e.g. `"Default" | "Emphasized" | "Positive"`
+ * @returns {Object|null} `{Default: "Default", ...}` or null
+ */
+WebCEnumRegistry.parseEnumUnion = function (typeText) {
+    if (typeof typeText !== 'string' || typeText.indexOf('|') === -1) {
+        return null;
+    }
+
+    var members = typeText.split('|');
+    var values = Object.create(null);
+    var count = 0;
+
+    for (var i = 0; i < members.length; i++) {
+        var member = members[i].trim();
+        var match = /^"([^"]*)"$/.exec(member) || /^'([^']*)'$/.exec(member);
+        if (!match) {
+            // A non-literal member (e.g. `undefined`, `string`, `ButtonDesign`)
+            // means this is not a plain string-literal enum — bail out.
+            return null;
+        }
+        var value = match[1];
+        values[value] = value;
+        count++;
+    }
+
+    return count >= 2 ? values : null;
+};
+
+/**
+ * Parse a Custom Elements Manifest into (or merged onto) a
+ * `tag -> property -> {label: value}` map.
+ *
+ * @param {Object} manifest - parsed custom-elements-internal.json
+ * @param {Object} [into] - existing map to merge onto
+ * @returns {Object}
+ */
+WebCEnumRegistry.parseManifest = function (manifest, into) {
+    into = into || Object.create(null);
+
+    if (!manifest || !Array.isArray(manifest.modules)) {
+        return into;
+    }
+
+    manifest.modules.forEach(function (mod) {
+        var declarations = (mod && mod.declarations) || [];
+        declarations.forEach(function (decl) {
+            if (!decl || !decl.tagName || !Array.isArray(decl.attributes)) {
+                return;
+            }
+            var tag = decl.tagName;
+            decl.attributes.forEach(function (attr) {
+                var values = WebCEnumRegistry.parseEnumUnion(attr && attr.type && attr.type.text);
+                if (!values) {
+                    return;
+                }
+                // `fieldName` is the class property (camelCase, matching the
+                // runtime property key); `name` may be the kebab-case attribute.
+                var property = attr.fieldName || attr.name;
+                if (!property) {
+                    return;
+                }
+                if (!into[tag]) {
+                    into[tag] = Object.create(null);
+                }
+                into[tag][property] = values;
+            });
+        });
+    });
+
+    return into;
+};
+
+/**
+ * Build the ordered list of candidate manifest URLs for a package: exact
+ * version on each host first, then the nearest published minor (jsDelivr and
+ * unpkg both resolve `@<major>.<minor>` to the latest matching patch) so
+ * internal/nightly builds still get a dropdown from the closest release.
+ *
+ * @param {string} pkg
+ * @param {string} version
+ * @returns {string[]}
+ */
+WebCEnumRegistry.prototype._candidateUrls = function (pkg, version) {
+    var specifiers = [version];
+
+    var parts = String(version).split('.');
+    if (parts.length >= 2 && /^\d+$/.test(parts[0]) && /^\d+$/.test(parts[1])) {
+        var minor = parts[0] + '.' + parts[1];
+        if (minor !== version) {
+            specifiers.push(minor);
+        }
+    }
+
+    var urls = [];
+    specifiers.forEach(function (specifier) {
+        WebCEnumRegistry.CDN_HOSTS.forEach(function (host) {
+            urls.push(host + pkg + '@' + specifier + WebCEnumRegistry.MANIFEST_PATH);
+        });
+    });
+    return urls;
+};
+
+/**
+ * Fetch and parse the manifest for one package, trying each candidate URL until
+ * one succeeds. Resolves to a partial map (possibly empty on total failure).
+ *
+ * @param {string} pkg
+ * @param {string} version
+ * @returns {Promise<Object>}
+ * @private
+ */
+WebCEnumRegistry.prototype._fetchPackage = function (pkg, version) {
+    var self = this;
+    var urls = this._candidateUrls(pkg, version);
+
+    var attempt = function (index) {
+        if (index >= urls.length) {
+            return Promise.resolve(Object.create(null));
+        }
+        return self._fetch(urls[index])
+            .then(function (response) {
+                if (!response || !response.ok) {
+                    return attempt(index + 1);
+                }
+                return response.json().then(function (json) {
+                    return WebCEnumRegistry.parseManifest(json);
+                });
+            })
+            .catch(function () {
+                return attempt(index + 1);
+            });
+    };
+
+    return attempt(0);
+};
+
+/**
+ * @param {string} version
+ * @returns {Promise<Object|null>}
+ * @private
+ */
+WebCEnumRegistry.prototype._loadFromStorage = function (version) {
+    var self = this;
+    if (!this._storage) {
+        return Promise.resolve(null);
+    }
+    var key = WebCEnumRegistry.storageKey(version);
+    return new Promise(function (resolve) {
+        try {
+            self._storage.get([key], function (result) {
+                resolve((result && result[key]) || null);
+            });
+        } catch (e) {
+            resolve(null);
+        }
+    });
+};
+
+/**
+ * Persist a version's enum map, maintaining a bounded, least-recently-saved
+ * cache: the version is moved to the most-recent slot and any versions past
+ * `MAX_STORED_VERSIONS` are removed. Best-effort — storage errors are ignored,
+ * and the read-modify-write of the index is not transactional (concurrent
+ * saves of different versions may under-evict, never lose the current entry).
+ *
+ * @param {string} version
+ * @param {Object} map
+ * @private
+ */
+WebCEnumRegistry.prototype._saveToStorage = function (version, map) {
+    var self = this;
+    if (!this._storage) {
+        return;
+    }
+    try {
+        this._storage.get([WebCEnumRegistry.INDEX_KEY], function (result) {
+            var index = (result && result[WebCEnumRegistry.INDEX_KEY]) || [];
+            if (!Array.isArray(index)) {
+                index = [];
+            }
+            // Move this version to the most-recent slot (end), de-duplicated.
+            index = index.filter(function (v) { return v !== version; });
+            index.push(version);
+
+            // Evict the oldest versions beyond the cap.
+            var removeKeys = [];
+            while (index.length > WebCEnumRegistry.MAX_STORED_VERSIONS) {
+                removeKeys.push(WebCEnumRegistry.storageKey(index.shift()));
+            }
+
+            var items = Object.create(null);
+            items[WebCEnumRegistry.INDEX_KEY] = index;
+            items[WebCEnumRegistry.storageKey(version)] = map;
+
+            if (removeKeys.length && typeof self._storage.remove === 'function') {
+                try {
+                    self._storage.remove(removeKeys, function () { /* best-effort */ });
+                } catch (e) {
+                    // best-effort
+                }
+            }
+            try {
+                self._storage.set(items, function () { /* best-effort */ });
+            } catch (e) {
+                // best-effort
+            }
+        });
+    } catch (e) {
+        // best-effort
+    }
+};
+
+/**
+ * Ensure the enum map for `version` is loaded (memory -> storage -> CDN).
+ * Concurrent calls for the same version share one in-flight fetch. Resolves to
+ * the map; on total failure the map is empty and `getEnumValues` returns null
+ * (the caller then keeps the plain-string behaviour).
+ *
+ * @param {string} version
+ * @returns {Promise<Object>}
+ */
+WebCEnumRegistry.prototype.prime = function (version) {
+    var self = this;
+
+    if (!version || !this._fetch) {
+        return Promise.resolve(Object.create(null));
+    }
+    if (this._memory[version]) {
+        return Promise.resolve(this._memory[version]);
+    }
+    if (this._pending[version]) {
+        return this._pending[version];
+    }
+
+    var promise = this._loadFromStorage(version).then(function (cached) {
+        if (cached) {
+            self._memory[version] = cached;
+            return cached;
+        }
+
+        return Promise.all(self._packages.map(function (pkg) {
+            return self._fetchPackage(pkg, version);
+        })).then(function (partials) {
+            var merged = Object.create(null);
+            partials.forEach(function (partial) {
+                Object.keys(partial).forEach(function (tag) {
+                    if (!merged[tag]) {
+                        merged[tag] = Object.create(null);
+                    }
+                    Object.keys(partial[tag]).forEach(function (prop) {
+                        merged[tag][prop] = partial[tag][prop];
+                    });
+                });
+            });
+
+            self._memory[version] = merged;
+            // Only persist a non-empty result so a transient network failure
+            // doesn't get cached as "this version has no enums".
+            if (Object.keys(merged).length) {
+                self._saveToStorage(version, merged);
+            }
+            return merged;
+        });
+    }).then(function (map) {
+        delete self._pending[version];
+        return map;
+    }, function (error) {
+        delete self._pending[version];
+        // Cache an empty map in memory so we don't refetch on every select in
+        // this session; a DevTools reload re-primes.
+        self._memory[version] = self._memory[version] || Object.create(null);
+        return self._memory[version];
+    });
+
+    this._pending[version] = promise;
+    return promise;
+};
+
+/**
+ * Synchronous lookup of a property's enum values. Returns null unless the
+ * version has been primed and the tag/property is a known enum.
+ *
+ * @param {string} version
+ * @param {string} tag - custom element tag, e.g. `ui5-button`
+ * @param {string} property - property name, e.g. `design`
+ * @returns {Object|null} `{label: value}` map or null
+ */
+WebCEnumRegistry.prototype.getEnumValues = function (version, tag, property) {
+    var map = this._memory[version];
+    if (!map || !map[tag]) {
+        return null;
+    }
+    return map[tag][property] || null;
+};
+
+module.exports = WebCEnumRegistry;

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -237,6 +237,34 @@
         });
     }
 
+    // Resolve which runtime a given component belongs to and return THAT
+    // runtime's version. A single page can load several UI5 Web Components
+    // runtimes at once (multiple bundles / micro-frontends), each potentially a
+    // different version. Enum values must be matched to the exact version, so
+    // we cannot just assume the primary runtime. Every runtime scopes its
+    // custom element tags with a unique suffix (ui5-button-<scopingSuffix>), so
+    // the element's scoped tag identifies its runtime. Falls back to the
+    // primary detected version when the component is unscoped or no suffix
+    // matches. See packages/base/src/CustomElementsScopeUtils.ts and Runtimes.ts.
+    function _getRuntimeVersionForTag(scopedTag, pureTag) {
+        var version = _getVersion();
+        if (!scopedTag || !pureTag || scopedTag === pureTag) {
+            return version;
+        }
+        var prefix = pureTag + '-';
+        if (scopedTag.indexOf(prefix) !== 0) {
+            return version;
+        }
+        var suffix = scopedTag.slice(prefix.length);
+        _getRuntimes().forEach(function (rt) {
+            var rtSuffix = _safe(function () { return rt.scopingSuffix; }, '');
+            if (rtSuffix && rtSuffix === suffix) {
+                version = _safe(function () { return rt.version; }, version) || version;
+            }
+        });
+        return version;
+    }
+
     window.__ui5WebComponentsToolsAPI = {
 
         getFrameworkInformation: function () {
@@ -271,6 +299,15 @@
             result.own = Object.create(null);
             result.own.meta = Object.create(null);
             result.own.meta.controlName = metadata.getTag ? metadata.getTag() : element.localName;
+            // Unscoped tag (e.g. "ui5-button") for matching against the CDN
+            // custom-elements manifest. getTag() may carry a scoping suffix
+            // (ui5-button-<suffix>) chosen per app/runtime, which the manifest
+            // does not know about. See UI5ElementMetadata.getPureTag/getTag.
+            result.own.meta.pureTag = metadata.getPureTag ? metadata.getPureTag() : result.own.meta.controlName;
+            // Version of the runtime THIS element belongs to (see
+            // _getRuntimeVersionForTag) so the panel fetches the matching CDN
+            // manifest on multi-runtime pages, not just the primary version.
+            result.own.meta.version = _getRuntimeVersionForTag(result.own.meta.controlName, result.own.meta.pureTag);
 
             result.own.properties = Object.create(null);
             var propNames = Object.keys(propsMetadata);

--- a/app/vendor/WebComponentsToolsAPI.js
+++ b/app/vendor/WebComponentsToolsAPI.js
@@ -122,12 +122,13 @@
         return slotData.type === Node ? 'Node' : 'HTMLElement';
     }
 
-    // Returns the array of runtime descriptors the framework registers on the
-    // shared-resources meta element. See packages/base/src/Runtimes.ts.
-    // Each runtime exposes: version, alias, description, registeredTags,
+    // Returns the raw array of runtime descriptors the framework registers on
+    // the shared-resources meta element. See packages/base/src/Runtimes.ts.
+    // Each runtime exposes (mostly as live getters): version, alias,
+    // description, importMetaUrl, scopingSuffix, registeredTags,
     // registeredFeatures, configuration (theme, language, timezone, etc.),
-    // openUI5Detected, openUI5LoadedFirst, and more. Returns [] if the
-    // meta element or Runtimes property is missing.
+    // openUI5Detected, openUI5LoadedFirst. Returns [] if the meta element or
+    // Runtimes property is missing.
     function _getRuntimes() {
         try {
             var meta = document.querySelector('meta[name="ui5-shared-resources"]');
@@ -140,10 +141,106 @@
         return [];
     }
 
+    // Many runtime fields are live getters that call framework functions and
+    // can throw (e.g. on partially-booted runtimes). Read every field through
+    // this guard so one bad getter never breaks the whole App Info tab.
+    function _safe(fn, fallback) {
+        try {
+            var value = fn();
+            return value === undefined ? fallback : value;
+        } catch (e) {
+            return fallback;
+        }
+    }
+
+    // Count live UI5 web component instances per tag name, walking the whole
+    // document including shadow roots. Light-DOM-only queries miss components
+    // rendered inside other components' shadow roots, so we recurse. Returns a
+    // plain map { localName: count }.
+    function _getTagUsageCounts() {
+        var counts = Object.create(null);
+
+        function walk(root) {
+            var all = root.querySelectorAll('*');
+            for (var i = 0; i < all.length; i++) {
+                var el = all[i];
+                if (el.isUI5Element === true) {
+                    var tag = el.localName;
+                    counts[tag] = (counts[tag] || 0) + 1;
+                }
+                if (el.shadowRoot) {
+                    walk(el.shadowRoot);
+                }
+            }
+        }
+
+        walk(document);
+        return counts;
+    }
+
+    // Look up how many instances of a registered tag are on the page.
+    // `registeredTags` comes from getMetadata().getTag(), which already applies
+    // any scoping suffix (ui5-button-<suffix>), and the DOM elements carry that
+    // same scoped name — so usageCounts[tag] matches directly. The extra
+    // scoped-spelling lookup below is a defensive no-op for that case and only
+    // contributes if a framework version were to expose base (unscoped) tags.
+    // See packages/base/src/UI5ElementMetadata.ts (getTag) and
+    // packages/base/src/CustomElementsScopeUtils.ts.
+    function _usageForTag(usageCounts, tag, scopingSuffix) {
+        var count = usageCounts[tag] || 0;
+        if (scopingSuffix) {
+            count += usageCounts[tag + '-' + scopingSuffix] || 0;
+        }
+        return count;
+    }
+
+    // Normalize the raw runtime descriptors into plain, serializable objects
+    // (the panel receives these over postMessage, so no getters/functions can
+    // survive). Splits each runtime's registered tags into used/unused with
+    // instance counts.
+    function _normalizeRuntimes() {
+        var raw = _getRuntimes();
+        var usageCounts = _getTagUsageCounts();
+
+        return raw.map(function (rt, index) {
+            var scopingSuffix = _safe(function () { return rt.scopingSuffix; }, '');
+            var registeredTags = _safe(function () { return rt.registeredTags; }, []) || [];
+            var usedTags = [];
+            var unusedTags = [];
+
+            registeredTags.forEach(function (tag) {
+                var count = _usageForTag(usageCounts, tag, scopingSuffix);
+                if (count > 0) {
+                    usedTags.push({ tag: tag, count: count });
+                } else {
+                    unusedTags.push(tag);
+                }
+            });
+
+            return {
+                index: index,
+                version: _safe(function () { return rt.version; }, ''),
+                isNext: _safe(function () { return rt.isNext; }, false),
+                buildTime: _safe(function () { return rt.buildTime; }, undefined),
+                alias: _safe(function () { return rt.alias; }, ''),
+                description: _safe(function () { return rt.description; }, ''),
+                importMetaUrl: _safe(function () { return rt.importMetaUrl; }, ''),
+                scopingSuffix: scopingSuffix,
+                registeredTags: registeredTags,
+                usedTags: usedTags,
+                unusedTags: unusedTags,
+                registeredFeatures: _safe(function () { return rt.registeredFeatures; }, []) || [],
+                configuration: _safe(function () { return rt.configuration; }, null),
+                openUI5Detected: _safe(function () { return rt.openUI5Detected; }, undefined),
+                openUI5LoadedFirst: _safe(function () { return rt.openUI5LoadedFirst; }, undefined)
+            };
+        });
+    }
+
     window.__ui5WebComponentsToolsAPI = {
 
         getFrameworkInformation: function () {
-            var runtimes = _getRuntimes();
+            var runtimes = _normalizeRuntimes();
             var primary = runtimes[0] || {};
             return Promise.resolve({
                 commonInformation: {

--- a/tests/modules/webc/WebCEnumRegistry.spec.js
+++ b/tests/modules/webc/WebCEnumRegistry.spec.js
@@ -1,0 +1,293 @@
+'use strict';
+
+const WebCEnumRegistry = require('../../../app/scripts/modules/webc/WebCEnumRegistry.js');
+
+/**
+ * In-memory fake of the `chrome.storage.local` surface.
+ * @returns {{storage: Object, data: Object}}
+ */
+function createFakeStorage() {
+    const data = {};
+    const storage = {
+        get: function (keys, callback) {
+            const result = {};
+            keys.forEach(function (key) {
+                if (Object.prototype.hasOwnProperty.call(data, key)) {
+                    result[key] = data[key];
+                }
+            });
+            callback(result);
+        },
+        set: function (items, callback) {
+            Object.keys(items).forEach(function (key) {
+                data[key] = items[key];
+            });
+            callback && callback();
+        },
+        remove: function (keys, callback) {
+            (Array.isArray(keys) ? keys : [keys]).forEach(function (key) {
+                delete data[key];
+            });
+            callback && callback();
+        }
+    };
+    return { storage: storage, data: data };
+}
+
+/**
+ * Fake `fetch` returning a manifest for URLs matching `okMatcher`, 404 otherwise.
+ * Records every requested URL.
+ * @param {Object} manifestByPredicate - map of matcher -> manifest
+ * @returns {{fetch: Function, calls: string[]}}
+ */
+function createFakeFetch(routes) {
+    const calls = [];
+    const fetchFn = function (url) {
+        calls.push(url);
+        for (let i = 0; i < routes.length; i++) {
+            if (routes[i].match(url)) {
+                return Promise.resolve({
+                    ok: true,
+                    json: function () { return Promise.resolve(routes[i].manifest); }
+                });
+            }
+        }
+        return Promise.resolve({ ok: false, status: 404, json: function () { return Promise.resolve({}); } });
+    };
+    return { fetch: fetchFn, calls: calls };
+}
+
+const BUTTON_MANIFEST = {
+    modules: [{
+        declarations: [{
+            kind: 'class',
+            tagName: 'ui5-button',
+            attributes: [
+                { name: 'design', fieldName: 'design', type: { text: '"Default" | "Emphasized" | "Positive"' } },
+                { name: 'text', fieldName: 'text', type: { text: 'string' } },
+                { name: 'disabled', fieldName: 'disabled', type: { text: 'boolean' } }
+            ]
+        }]
+    }]
+};
+
+describe('WebCEnumRegistry', function () {
+
+    describe('parseEnumUnion', function () {
+        it('parses a union of quoted string literals into a label->value map', function () {
+            const values = WebCEnumRegistry.parseEnumUnion('"Default" | "Emphasized" | "Positive"');
+            expect(values).to.deep.equal({ Default: 'Default', Emphasized: 'Emphasized', Positive: 'Positive' });
+        });
+
+        it('handles single-quoted literals', function () {
+            const values = WebCEnumRegistry.parseEnumUnion('\'A\' | \'B\'');
+            expect(values).to.deep.equal({ A: 'A', B: 'B' });
+        });
+
+        it('returns null for a single literal (not an enum)', function () {
+            expect(WebCEnumRegistry.parseEnumUnion('"Default"')).to.equal(null);
+        });
+
+        it('returns null when a member is not a string literal', function () {
+            expect(WebCEnumRegistry.parseEnumUnion('"Default" | ButtonDesign')).to.equal(null);
+            expect(WebCEnumRegistry.parseEnumUnion('string')).to.equal(null);
+            expect(WebCEnumRegistry.parseEnumUnion('boolean')).to.equal(null);
+        });
+
+        it('returns null for non-string input', function () {
+            expect(WebCEnumRegistry.parseEnumUnion(undefined)).to.equal(null);
+            expect(WebCEnumRegistry.parseEnumUnion(null)).to.equal(null);
+        });
+    });
+
+    describe('parseManifest', function () {
+        it('builds a tag -> property -> values map for enum attributes only', function () {
+            const map = WebCEnumRegistry.parseManifest(BUTTON_MANIFEST);
+            expect(map['ui5-button'].design).to.deep.equal({ Default: 'Default', Emphasized: 'Emphasized', Positive: 'Positive' });
+            expect(map['ui5-button'].text).to.equal(undefined);
+            expect(map['ui5-button'].disabled).to.equal(undefined);
+        });
+
+        it('prefers fieldName over attribute name', function () {
+            const map = WebCEnumRegistry.parseManifest({
+                modules: [{ declarations: [{
+                    tagName: 'ui5-x',
+                    attributes: [{ name: 'my-prop', fieldName: 'myProp', type: { text: '"a" | "b"' } }]
+                }] }]
+            });
+            expect(map['ui5-x'].myProp).to.deep.equal({ a: 'a', b: 'b' });
+            expect(map['ui5-x']['my-prop']).to.equal(undefined);
+        });
+
+        it('ignores declarations without a tagName or attributes', function () {
+            const map = WebCEnumRegistry.parseManifest({
+                modules: [{ declarations: [{ kind: 'variable', name: 'foo' }] }]
+            });
+            expect(Object.keys(map)).to.have.length(0);
+        });
+
+        it('tolerates malformed input', function () {
+            expect(WebCEnumRegistry.parseManifest(null)).to.deep.equal({});
+            expect(WebCEnumRegistry.parseManifest({})).to.deep.equal({});
+        });
+    });
+
+    describe('_candidateUrls', function () {
+        it('lists exact version on both hosts, then nearest minor on both', function () {
+            const registry = new WebCEnumRegistry({ fetch: function () {}, storage: createFakeStorage().storage });
+            const urls = registry._candidateUrls('@ui5/webcomponents', '2.26.3');
+            expect(urls).to.deep.equal([
+                'https://cdn.jsdelivr.net/npm/@ui5/webcomponents@2.26.3/dist/custom-elements-internal.json',
+                'https://unpkg.com/@ui5/webcomponents@2.26.3/dist/custom-elements-internal.json',
+                'https://cdn.jsdelivr.net/npm/@ui5/webcomponents@2.26/dist/custom-elements-internal.json',
+                'https://unpkg.com/@ui5/webcomponents@2.26/dist/custom-elements-internal.json'
+            ]);
+        });
+
+        it('does not add a minor specifier when version is already a bare minor', function () {
+            const registry = new WebCEnumRegistry({ fetch: function () {}, storage: createFakeStorage().storage });
+            const urls = registry._candidateUrls('@ui5/webcomponents', '2.26');
+            expect(urls).to.have.length(2);
+        });
+    });
+
+    describe('prime / getEnumValues', function () {
+        it('fetches, parses and exposes enum values', function () {
+            const fake = createFakeFetch([{
+                match: function (url) { return url.indexOf('@ui5/webcomponents@2.26.0') !== -1; },
+                manifest: BUTTON_MANIFEST
+            }]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: createFakeStorage().storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            return registry.prime('2.26.0').then(function () {
+                expect(registry.getEnumValues('2.26.0', 'ui5-button', 'design'))
+                    .to.deep.equal({ Default: 'Default', Emphasized: 'Emphasized', Positive: 'Positive' });
+                expect(registry.getEnumValues('2.26.0', 'ui5-button', 'text')).to.equal(null);
+                expect(registry.getEnumValues('2.26.0', 'ui5-unknown', 'x')).to.equal(null);
+            });
+        });
+
+        it('returns null lookups before priming', function () {
+            const registry = new WebCEnumRegistry({ fetch: function () {}, storage: createFakeStorage().storage });
+            expect(registry.getEnumValues('2.26.0', 'ui5-button', 'design')).to.equal(null);
+        });
+
+        it('falls back to the nearest minor when the exact version is unpublished', function () {
+            const fake = createFakeFetch([{
+                match: function (url) { return url.indexOf('@ui5/webcomponents@2.26/') !== -1; },
+                manifest: BUTTON_MANIFEST
+            }]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: createFakeStorage().storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            return registry.prime('2.26.99-nightly').then(function () {
+                expect(registry.getEnumValues('2.26.99-nightly', 'ui5-button', 'design'))
+                    .to.deep.equal({ Default: 'Default', Emphasized: 'Emphasized', Positive: 'Positive' });
+            });
+        });
+
+        it('serves a cached map from storage without fetching', function () {
+            const fakeStorage = createFakeStorage();
+            fakeStorage.data[WebCEnumRegistry.storageKey('2.26.0')] = {
+                'ui5-button': { design: { Default: 'Default' } }
+            };
+            const fake = createFakeFetch([]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: fakeStorage.storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            return registry.prime('2.26.0').then(function () {
+                expect(fake.calls).to.have.length(0);
+                expect(registry.getEnumValues('2.26.0', 'ui5-button', 'design')).to.deep.equal({ Default: 'Default' });
+            });
+        });
+
+        it('persists a fetched map to storage', function () {
+            const fakeStorage = createFakeStorage();
+            const fake = createFakeFetch([{
+                match: function (url) { return url.indexOf('@2.26.0') !== -1; },
+                manifest: BUTTON_MANIFEST
+            }]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: fakeStorage.storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            return registry.prime('2.26.0').then(function () {
+                expect(fakeStorage.data[WebCEnumRegistry.storageKey('2.26.0')]['ui5-button'].design)
+                    .to.deep.equal({ Default: 'Default', Emphasized: 'Emphasized', Positive: 'Positive' });
+            });
+        });
+
+        it('shares one in-flight fetch across concurrent primes', function () {
+            const fake = createFakeFetch([{
+                match: function (url) { return url.indexOf('@2.26.0') !== -1; },
+                manifest: BUTTON_MANIFEST
+            }]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: createFakeStorage().storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            const callsBefore = fake.calls.length;
+            return Promise.all([registry.prime('2.26.0'), registry.prime('2.26.0')]).then(function () {
+                // Only one URL resolved (the first candidate); no duplicate fan-out.
+                expect(fake.calls.length).to.equal(callsBefore + 1);
+            });
+        });
+
+        it('resolves to an empty map (null lookups) when all fetches fail', function () {
+            const fake = createFakeFetch([]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: createFakeStorage().storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            return registry.prime('9.9.9').then(function () {
+                expect(registry.getEnumValues('9.9.9', 'ui5-button', 'design')).to.equal(null);
+            });
+        });
+
+        it('evicts the least-recently-saved version past the cap', function () {
+            const fakeStorage = createFakeStorage();
+            const fake = createFakeFetch([{
+                match: function () { return true; },
+                manifest: BUTTON_MANIFEST
+            }]);
+            const registry = new WebCEnumRegistry({
+                fetch: fake.fetch,
+                storage: fakeStorage.storage,
+                packages: ['@ui5/webcomponents']
+            });
+
+            // Prime one more distinct version than the cap allows, in order.
+            const versions = [];
+            for (let i = 0; i <= WebCEnumRegistry.MAX_STORED_VERSIONS; i++) {
+                versions.push('2.' + i + '.0');
+            }
+
+            return versions.reduce(function (chain, v) {
+                return chain.then(function () { return registry.prime(v); });
+            }, Promise.resolve()).then(function () {
+                const index = fakeStorage.data[WebCEnumRegistry.INDEX_KEY];
+                expect(index).to.have.length(WebCEnumRegistry.MAX_STORED_VERSIONS);
+                // Oldest (first primed) evicted; newest retained.
+                expect(fakeStorage.data[WebCEnumRegistry.storageKey(versions[0])]).to.equal(undefined);
+                expect(fakeStorage.data[WebCEnumRegistry.storageKey(versions[versions.length - 1])])
+                    .to.not.equal(undefined);
+            });
+        });
+    });
+});


### PR DESCRIPTION
**Background**
UI5 Web Components enum properties (e.g. ui5-button design) only render as dropdowns in the inspector when consumed via the OpenUI5 wrappers, which register their enums as sap/ui/base/DataType. Pure web components and their @ui5/webcomponents-react wrappers showed a plain editable text field instead, because the runtime metadata erases the enum's type identity (the property type collapses to the String constructor — no enum name, no value list).

This PR restores enum dropdowns for the pure-webc and React-wrapper paths by sourcing the allowed values from the published Custom Elements Manifest (dist/custom-elements-internal.json), fetched from a CDN and keyed to the framework version actually running on the page.

**Implementation**

- New WebCEnumRegistry module (app/scripts/modules/webc/): version-keyed prime() / getEnumValues() with a memory → chrome.storage.local → CDN resolution chain, in-flight de-duplication, nearest-published-minor fallback (@<major>.<minor>, which both CDNs resolve) for internal/nightly builds, and a bounded (LRU) storage cache.
- CDN: jsDelivr primary, unpkg fallback. Fetches the four enum-bearing family packages: @ui5/webcomponents, -fiori, -compat, -ai (verified these carry all enum tags; -base publishes a manifest but has none).
- Runs in the panel (extension context), never the page — the inspected app's CSP usually blocks third-party hosts. manifest.json extension_pages CSP is relaxed with connect-src … cdn.jsdelivr.net unpkg.com (only connect-src; script-src/object-src stay 'self').
- Multi-runtime aware: the version is resolved per component from its scoping suffix, so pages running several UI5 Web Components runtimes at different versions match each component to its own manifest.
- Scoping-safe: lookups use the pure/unscoped tag (ui5-button), so app/runtime scoping suffixes (ui5-button-<suffix>) don't break matching.
- No stale renders: web-component rendering is deferred behind the async manifest fetch, guarded by a selection token so an out-of-order fetch can't overwrite a newer selection.
- Any failure/offline → falls back silently to the plain-string field (no dropdown). Classic UI5 rendering is unchanged.

**Also included (stacked commits)**

This branch is stacked on two earlier ones:
- feat: show per-runtime UI5 Web Components info in App Info tab
- fix: resolve web component enum properties as dropdowns via DataType (the OpenUI5-wrapper path)
